### PR TITLE
Restaurant and menu API improvements

### DIFF
--- a/src/restaraunts/endpoints/__init__.py
+++ b/src/restaraunts/endpoints/__init__.py
@@ -3,6 +3,6 @@ from .v1 import menu, restaraunt, order, item
 
 v1_router = APIRouter(prefix="/v1")
 v1_router.include_router(menu.router)
+v1_router.include_router(item.router)
 v1_router.include_router(restaraunt.router)
 v1_router.include_router(order.router)
-v1_router.include_router(item.router)

--- a/src/restaraunts/endpoints/v1/item.py
+++ b/src/restaraunts/endpoints/v1/item.py
@@ -5,12 +5,12 @@ from datetime import datetime
 
 router = APIRouter(tags=['item'])
 
-@router.get('/restaurants/{restaurant_id}/menu/{menu_id}/items')
+@router.get('/restaraunts/{restaraunt_id}/menu/{menu_id}/items')
 async def get_items():
     ...
 
 
-@router.get('/restaurants/{restaurant_id}/menu/{menu_id}/items/{item_id}')
+@router.get('/restaraunts/{restaraunt_id}/menu/{menu_id}/items/{item_id}')
 async def get_item(
         item_id: str
 ) -> Item:
@@ -24,12 +24,12 @@ async def get_item(
     # )
 
 
-@router.get('/restaurants/{restaurant_id}/orders/{order_id}/items')
+@router.get('/restaraunts/{restaraunt_id}/orders/{order_id}/items')
 async def get_ordereditems():
     ...
 
 
-@router.get('/restaurants/{restaurant_id}/orders/{order_id}/items/{item_id}')
+@router.get('/restaraunts/{restaraunt_id}/orders/{order_id}/items/{item_id}')
 async def get_ordereditem(
         item_id: str
 ) -> OrderedItem:
@@ -44,7 +44,7 @@ async def get_ordereditem(
     # )
 
 
-@router.patch("/restaurants/{restaurant_id}/orders/{order_id}/items/{item_id}", response_model=dict)
+@router.patch("/restaraunts/{restaraunt_id}/orders/{order_id}/items/{item_id}", response_model=dict)
 def update_ordereditem_status(
     item_id: int, 
     ordereditem_update: OrderedItemStatus
@@ -52,7 +52,7 @@ def update_ordereditem_status(
     pass
 
 
-@router.delete('/restaurants/{restaurant_id}/orders/{order_id}/items/{item_id}')
+@router.delete('/restaraunt/{restaraunt_id}/orders/{order_id}/items/{item_id}')
 async def delete_ordereditem_from_order(
     item_id: str,
     order_id: str

--- a/src/restaraunts/endpoints/v1/item.py
+++ b/src/restaraunts/endpoints/v1/item.py
@@ -1,27 +1,48 @@
-from fastapi import APIRouter
-from src.restaraunts.schemas.item import Item
+from fastapi import APIRouter, status
+from src.restaraunts.repo import item
+from src.restaraunts.schemas.item import Item, ItemCreate, ItemResponse
 from src.restaraunts.schemas.ordereditem import OrderedItem, OrderedItemStatus
-from datetime import datetime
 
 router = APIRouter(tags=['item'])
 
-@router.get('/restaraunts/{restaraunt_id}/menu/{menu_id}/items')
-async def get_items():
-    ...
+
+@router.get('/restaraunts/items', summary="Получить список всех товаров")
+async def get_all() -> list[Item]:
+    items = await item.get_all()
+    return items
 
 
-@router.get('/restaraunts/{restaraunt_id}/menu/{menu_id}/items/{item_id}')
-async def get_item(
-        item_id: str
-) -> Item:
-    ...
-    # return Item(
-    #     id= item_id,
-    #     created_at= datetime.now(),
-    #     updated_at= datetime.now(),
-    #     price= 999,
-    #     name= 'test_item_name'
-    # )
+@router.get(
+        '/restaraunts/{restaraunt_id}/menu/{menu_id}/items',
+        summary="Получить список всех товаров (для меню)"
+)
+async def get_all_for_m(menu_id: int) -> list[Item]:
+    items= await item.get_all_for_menu(menu_id)
+    return items
+
+
+@router.get(
+        '/restaraunts/{restaraunt_id}/menu/{menu_id}/items/{item_id}',
+        summary="Получить детальную информацию о товаре (для меню)"
+)
+async def get_item(menu_id: int, item_id: int) -> Item:
+    i = await item.get_item_for_menu(menu_id, item_id)
+    return i
+   
+
+@router.post(
+    "/restaraunts/items", 
+    status_code=status.HTTP_201_CREATED,
+    summary="Создать новый товар"
+)
+async def create_item(item_data: ItemCreate) -> ItemResponse:
+    new_id = await item.add_item(item_data.name, item_data.price)
+    return ItemResponse(
+        id=new_id, 
+        name=item_data.name,
+        price=item_data.price,
+        status="created"
+    )
 
 
 @router.get('/restaraunts/{restaraunt_id}/orders/{order_id}/items')

--- a/src/restaraunts/endpoints/v1/item.py
+++ b/src/restaraunts/endpoints/v1/item.py
@@ -52,7 +52,7 @@ def update_ordereditem_status(
     pass
 
 
-@router.delete('/restaraunt/{restaraunt_id}/orders/{order_id}/items/{item_id}')
+@router.delete('/restaraunts/{restaraunt_id}/orders/{order_id}/items/{item_id}')
 async def delete_ordereditem_from_order(
     item_id: str,
     order_id: str

--- a/src/restaraunts/endpoints/v1/item.py
+++ b/src/restaraunts/endpoints/v1/item.py
@@ -44,6 +44,16 @@ async def get_ordereditem(
     # )
 
 
+
+@router.post('/restaraunts/{restaraunt_id}/orders/{order_id}/items/{item_id}')
+async def add_item_to_order(
+    order_id: str,
+    item_id: str
+):
+    pass
+
+
+
 @router.patch("/restaraunts/{restaraunt_id}/orders/{order_id}/items/{item_id}", response_model=dict)
 def update_ordereditem_status(
     item_id: int, 

--- a/src/restaraunts/endpoints/v1/menu.py
+++ b/src/restaraunts/endpoints/v1/menu.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, status
+from fastapi import APIRouter, status, HTTPException, Response
 from src.restaraunts.schemas.menu import Menu, MenuCreate, MenuResponse
-from src.restaraunts.repo import menu
+from src.restaraunts.schemas.menuitem import LinkItemResponse
+from src.restaraunts.repo import menu, item
 
 router = APIRouter(tags=['menu'])
 
@@ -33,4 +34,26 @@ async def create_menu(menu_data: MenuCreate) -> MenuResponse:
         id=new_id, 
         name=menu_data.name,
         status="created"
+    )
+
+@router.post(
+    "/restaraunts/{restaraunt_id}/menu/{menu_id}/items/{item_id}",
+    status_code=status.HTTP_201_CREATED,
+    summary="Привязать товар к меню",
+    responses={204: {"model": None}}
+)
+async def add_item_to_menu(menu_id: int, item_id: int) -> LinkItemResponse:
+    result = await menu.link_menu_and_iten(menu_id, item_id)
+    if result == "not_found":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Menu or Item not found"
+        )
+    if result == "already_exists":
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    all_items = await item.get_all_for_menu(menu_id)
+    return LinkItemResponse(
+        status="created",
+        menu_id=menu_id,
+        items=all_items
     )

--- a/src/restaraunts/endpoints/v1/menu.py
+++ b/src/restaraunts/endpoints/v1/menu.py
@@ -1,21 +1,20 @@
 from fastapi import APIRouter
 from src.restaraunts.schemas.menu import Menu
-from src.restaraunts.repo.menu import get_menus_for_restaraunt
+from src.restaraunts.repo import menu
 
 router = APIRouter(tags=['menu'])
 
 @router.get('/restaraunt/{restaraunt_id}/menu')
 async def get_menus(restaraunt_id: int) -> list[Menu]:
-    menus = await get_menus_for_restaraunt(restaraunt_id)
+    menus = await menu.get_all_for_restaraunt(restaraunt_id)
     return menus
 
 
 @router.get('/restaraunt/{restaraunt_id}/menu/{menu_id}')
-async def get_menu(
-        menu_id: str
-) -> Menu:
-        ...
+async def get_menu(restaraunt_id: int, menu_id: int) -> Menu:
+    m = await menu.get_menu_for_restaraunt(restaraunt_id, menu_id)
+    return m
+
 
 #async def create_menu():
 #    ... 
-

--- a/src/restaraunts/endpoints/v1/menu.py
+++ b/src/restaraunts/endpoints/v1/menu.py
@@ -4,8 +4,14 @@ from src.restaraunts.repo import menu
 
 router = APIRouter(tags=['menu'])
 
+@router.get('/restaraunts/menus')
+async def get_all() -> list[Menu]:
+    menus = await menu.get_all()
+    return menus
+
+
 @router.get('/restaraunt/{restaraunt_id}/menu')
-async def get_menus(restaraunt_id: int) -> list[Menu]:
+async def get_all_for_r(restaraunt_id: int) -> list[Menu]:
     menus = await menu.get_all_for_restaraunt(restaraunt_id)
     return menus
 

--- a/src/restaraunts/endpoints/v1/menu.py
+++ b/src/restaraunts/endpoints/v1/menu.py
@@ -10,17 +10,18 @@ async def get_all() -> list[Menu]:
     return menus
 
 
-@router.get('/restaraunt/{restaraunt_id}/menu')
+@router.get('/rrestaraunts/{restaraunt_id}/menu')
 async def get_all_for_r(restaraunt_id: int) -> list[Menu]:
     menus = await menu.get_all_for_restaraunt(restaraunt_id)
     return menus
 
 
-@router.get('/restaraunt/{restaraunt_id}/menu/{menu_id}')
+@router.get('/restaraunts/{restaraunt_id}/menu/{menu_id}')
 async def get_menu(restaraunt_id: int, menu_id: int) -> Menu:
     m = await menu.get_menu_for_restaraunt(restaraunt_id, menu_id)
     return m
 
 
-#async def create_menu():
-#    ... 
+@router.patch('/restaraunts/menu')
+async def create_menu(menu_name: str):
+    await menu.add_menu(menu_name)

--- a/src/restaraunts/endpoints/v1/menu.py
+++ b/src/restaraunts/endpoints/v1/menu.py
@@ -1,27 +1,36 @@
-from fastapi import APIRouter
-from src.restaraunts.schemas.menu import Menu
+from fastapi import APIRouter, status
+from src.restaraunts.schemas.menu import Menu, MenuCreate
 from src.restaraunts.repo import menu
 
 router = APIRouter(tags=['menu'])
 
-@router.get('/restaraunts/menus')
+@router.get('/restaraunts/menus', summary="Получить список всех меню")
 async def get_all() -> list[Menu]:
     menus = await menu.get_all()
     return menus
 
 
-@router.get('/rrestaraunts/{restaraunt_id}/menu')
+@router.get('/restaraunts/{restaraunt_id}/menu', summary="Получить список всех меню (для ресторана)")
 async def get_all_for_r(restaraunt_id: int) -> list[Menu]:
     menus = await menu.get_all_for_restaraunt(restaraunt_id)
     return menus
 
 
-@router.get('/restaraunts/{restaraunt_id}/menu/{menu_id}')
+@router.get('/restaraunts/{restaraunt_id}/menu/{menu_id}', summary="Получить детальную информацию о меню (для ресторана)")
 async def get_menu(restaraunt_id: int, menu_id: int) -> Menu:
     m = await menu.get_menu_for_restaraunt(restaraunt_id, menu_id)
     return m
 
 
-@router.patch('/restaraunts/menu')
-async def create_menu(menu_name: str):
-    await menu.add_menu(menu_name)
+@router.post(
+    "/restaraunts/menu", 
+    status_code=status.HTTP_201_CREATED,
+    summary="Создать новое меню"
+)
+async def create_menu(menu_data: MenuCreate):
+    new_id = await menu.add_menu(menu_data.name)
+    return {
+        "id": new_id, 
+        "name": menu_data.name,
+        "status": "created"
+    }

--- a/src/restaraunts/endpoints/v1/menu.py
+++ b/src/restaraunts/endpoints/v1/menu.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, status
-from src.restaraunts.schemas.menu import Menu, MenuCreate
+from src.restaraunts.schemas.menu import Menu, MenuCreate, MenuResponse
 from src.restaraunts.repo import menu
 
 router = APIRouter(tags=['menu'])
@@ -23,14 +23,14 @@ async def get_menu(restaraunt_id: int, menu_id: int) -> Menu:
 
 
 @router.post(
-    "/restaraunts/menu", 
+    "/restaraunts/menus", 
     status_code=status.HTTP_201_CREATED,
     summary="Создать новое меню"
 )
-async def create_menu(menu_data: MenuCreate):
+async def create_menu(menu_data: MenuCreate) -> MenuResponse:
     new_id = await menu.add_menu(menu_data.name)
-    return {
-        "id": new_id, 
-        "name": menu_data.name,
-        "status": "created"
-    }
+    return MenuResponse(
+        id=new_id, 
+        name=menu_data.name,
+        status="created"
+    )

--- a/src/restaraunts/endpoints/v1/order.py
+++ b/src/restaraunts/endpoints/v1/order.py
@@ -1,5 +1,5 @@
-from fastapi import APIRouter
-from src.restaraunts.schemas.order import Order, OrderStatus
+from fastapi import APIRouter, status
+from src.restaraunts.schemas.order import Order, OrderCreate, OrderResponse, OrderStatus
 from src.restaraunts.repo import order
 
 router = APIRouter(tags=['order'])
@@ -16,12 +16,19 @@ async def get_order(restaraunt_id: int, order_id: int) -> Order:
     return o
 
 
-@router.post('/restaraunts/{restaraunt_id}/orders')
-async def add_order(
-    order: Order
-):
-    #логика добавления заказа в БД
-    pass
+@router.post(
+        '/restaraunts/{restaraunt_id}/orders',
+        status_code=status.HTTP_201_CREATED,
+        summary="Создать новый заказ для ресторана",
+)
+async def create_order(restaraunt_id: int, order_data: OrderCreate) -> OrderResponse:
+    new_id = await order.add_order(order_data.price, restaraunt_id)
+    return OrderResponse(
+        id=new_id, 
+        price=order_data.price,
+        restaraunt_id=restaraunt_id,
+        status="Новый"
+    )
 
 
 @router.post('/restaraunts/{restaraunt_id}/orders/{order_id}/items/{item_id}')

--- a/src/restaraunts/endpoints/v1/order.py
+++ b/src/restaraunts/endpoints/v1/order.py
@@ -1,16 +1,22 @@
-from fastapi import APIRouter, status
-from src.restaraunts.schemas.order import Order, OrderCreate, OrderResponse, OrderStatus
+from fastapi import APIRouter, status, HTTPException
+from src.restaraunts.schemas.order import Order, OrderCreate, OrderResponse, OrderStatusUpdate
 from src.restaraunts.repo import order
 
 router = APIRouter(tags=['order'])
 
-@router.get('/restaraunts/{restaraunt_id}/orders', summary="Получить список всех заказов (для ресторана)")
+@router.get(
+        '/restaraunts/{restaraunt_id}/orders',
+        summary="Получить список всех заказов (для ресторана)"
+)
 async def get_all_for_r(restaraunt_id: int) -> list[Order]:
     orders = await order.get_all_for_restaraunt(restaraunt_id)
     return orders
 
 
-@router.get('/restaraunts/{restaraunt_id}/orders/{order_id}', summary="Получить детальную информацию о заказе (для ресторана)")
+@router.get(
+        '/restaraunts/{restaraunt_id}/orders/{order_id}',
+        summary="Получить детальную информацию о заказе (для ресторана)"
+)
 async def get_order(restaraunt_id: int, order_id: int) -> Order:
     o = await order.get_order_for_restaraunt(restaraunt_id, order_id)
     return o
@@ -19,7 +25,7 @@ async def get_order(restaraunt_id: int, order_id: int) -> Order:
 @router.post(
         '/restaraunts/{restaraunt_id}/orders',
         status_code=status.HTTP_201_CREATED,
-        summary="Создать новый заказ для ресторана",
+        summary="Создать новый заказ для ресторана"
 )
 async def create_order(restaraunt_id: int, order_data: OrderCreate) -> OrderResponse:
     new_id = await order.add_order(order_data.price, restaraunt_id)
@@ -31,17 +37,13 @@ async def create_order(restaraunt_id: int, order_data: OrderCreate) -> OrderResp
     )
 
 
-@router.post('/restaraunts/{restaraunt_id}/orders/{order_id}/items/{item_id}')
-async def add_item_to_order(
-    order_id: str,
-    item_id: str
-):
-    pass
 
-
-@router.patch("/restaraunts/{restaraunt_id}/orders/{order_id}", response_model=dict)
-def update_order_status(
-    order_id: int, 
-    order_update: OrderStatus
-):
-    pass
+@router.patch(
+        '/restaraunts/{restaraunt_id}/orders/{order_id}',
+        summary="Изменить статус заказа"
+)
+async def update_order_status(order_id: int, status_data: OrderStatusUpdate) -> Order:
+    updated_order = await order.update_status(order_id, status_data.new_status)
+    if not updated_order:
+        raise HTTPException(status_code=404, detail="Order not found")    
+    return updated_order

--- a/src/restaraunts/endpoints/v1/order.py
+++ b/src/restaraunts/endpoints/v1/order.py
@@ -4,12 +4,12 @@ from datetime import datetime
 
 router = APIRouter(tags=['order'])
 
-@router.get('/restaurants/{restaurant_id}/orders')
+@router.get('/restaraunts/{restaraunt_id}/orders')
 async def get_orders():
     ...
 
 
-@router.get('/restaurants/{restaurant_id}/orders/{order_id}')
+@router.get('/restaraunts/{restaraunt_id}/orders/{order_id}')
 async def get_order(
         order_id: str
 ) -> Order:
@@ -23,7 +23,7 @@ async def get_order(
     )
 
 
-@router.post('/restaurants/{restaurant_id}/orders')
+@router.post('/restaraunts/{restaraunt_id}/orders')
 async def add_order(
     order: Order
 ):
@@ -31,7 +31,7 @@ async def add_order(
     pass
 
 
-@router.post('/restaurants/{restaurant_id}/orders/{order_id}/items/{item_id}')
+@router.post('/restaraunts/{restaraunt_id}/orders/{order_id}/items/{item_id}')
 async def add_item_to_order(
     order_id: str,
     item_id: str
@@ -39,7 +39,7 @@ async def add_item_to_order(
     pass
 
 
-@router.patch("/restaurants/{restaurant_id}/orders/{order_id}", response_model=dict)
+@router.patch("/restaraunts/{restaraunt_id}/orders/{order_id}", response_model=dict)
 def update_order_status(
     order_id: int, 
     order_update: OrderStatus

--- a/src/restaraunts/endpoints/v1/order.py
+++ b/src/restaraunts/endpoints/v1/order.py
@@ -1,26 +1,19 @@
 from fastapi import APIRouter
 from src.restaraunts.schemas.order import Order, OrderStatus
-from datetime import datetime
+from src.restaraunts.repo import order
 
 router = APIRouter(tags=['order'])
 
-@router.get('/restaraunts/{restaraunt_id}/orders')
-async def get_orders():
-    ...
+@router.get('/restaraunts/{restaraunt_id}/orders', summary="Получить список всех заказов (для ресторана)")
+async def get_all_for_r(restaraunt_id: int) -> list[Order]:
+    orders = await order.get_all_for_restaraunt(restaraunt_id)
+    return orders
 
 
-@router.get('/restaraunts/{restaraunt_id}/orders/{order_id}')
-async def get_order(
-        order_id: str
-) -> Order:
-    return Order(
-        id= order_id,
-        created_at= datetime.now(),
-        updated_at= datetime.now(),
-        ordereditems= [],
-        status= 'Новый',
-        price= 9999
-    )
+@router.get('/restaraunts/{restaraunt_id}/orders/{order_id}', summary="Получить детальную информацию о заказе (для ресторана)")
+async def get_order(restaraunt_id: int, order_id: int) -> Order:
+    o = await order.get_order_for_restaraunt(restaraunt_id, order_id)
+    return o
 
 
 @router.post('/restaraunts/{restaraunt_id}/orders')
@@ -45,4 +38,3 @@ def update_order_status(
     order_update: OrderStatus
 ):
     pass
-

--- a/src/restaraunts/endpoints/v1/restaraunt.py
+++ b/src/restaraunts/endpoints/v1/restaraunt.py
@@ -1,3 +1,4 @@
+from typing import Any
 from fastapi import APIRouter, HTTPException, status, Response
 from src.restaraunts.schemas.restaraunt import Restaraunt
 from src.restaraunts.schemas.restarauntmenu import LinkMenuResponse
@@ -25,11 +26,12 @@ async def get_restaraunt(restaraunt_id: int) -> Restaraunt:
 
 @router.post(
     "/restaraunts/{restaraunt_id}/menu/{menu_id}",
+    response_model=LinkMenuResponse,
     status_code=status.HTTP_201_CREATED,
     summary="Привязать меню к ресторану",
     responses={204: {"model": None}}
 )
-async def add_menu_to_rest(restaraunt_id: int, menu_id: int) -> LinkMenuResponse | Response:
+async def add_menu_to_rest(restaraunt_id: int, menu_id: int) -> Any:
     result = await restaraunt.link_restaraunt_and_menu(restaraunt_id, menu_id)
     if result == "not_found":
         raise HTTPException(

--- a/src/restaraunts/endpoints/v1/restaraunt.py
+++ b/src/restaraunts/endpoints/v1/restaraunt.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, status, Response
 from src.restaraunts.schemas.restaraunt import Restaraunt
 from src.restaraunts.repo import restaraunt
+from src.restaraunts.repo import menu
 
 router = APIRouter(tags=['restaraunts'])
 
@@ -20,6 +21,13 @@ async def get_restaraunt(restaraunt_id: int) -> Restaraunt:
         )
     return r
 
-@router.patch("/restaraunt/{restaraunt_id}/menu/{menu_id}")
+@router.patch("/restaraunts/{restaraunt_id}/menu/{menu_id}")
 async def add_menu_to_rest(restaraunt_id: int, menu_id: int):
-    await restaraunt.link_restaurant_and_menu(restaraunt_id, menu_id)
+    result = await restaraunt.link_restaraunt_and_menu(restaraunt_id, menu_id)
+    if result == "not_found":
+        raise HTTPException(status_code=404, detail="Restaurant or Menu not found")
+    if result == "already_exists":
+        #связь уже есть(идемпотентно)
+        return Response(status_code=204)
+    all_menus = await menu.get_all_for_restaraunt(restaraunt_id)
+    return {"restaraunt_id": restaraunt_id, "menus": all_menus}

--- a/src/restaraunts/endpoints/v1/restaraunt.py
+++ b/src/restaraunts/endpoints/v1/restaraunt.py
@@ -5,13 +5,13 @@ from src.restaraunts.repo import menu
 
 router = APIRouter(tags=['restaraunts'])
 
-@router.get('/restaraunts')
+@router.get('/restaraunts', summary="Получить список всех ресторанов")
 async def get_restaraunts() -> list[Restaraunt]:
     restaraunts = await restaraunt.get_all()
     return restaraunts
 
 
-@router.get('/restaraunts/{restaraunt_id}')
+@router.get('/restaraunts/{restaraunt_id}', summary="Получить детальную информацию о ресторане")
 async def get_restaraunt(restaraunt_id: int) -> Restaraunt:
     r = await restaraunt.get_restaraunt(restaraunt_id)
     if r is None:
@@ -21,7 +21,12 @@ async def get_restaraunt(restaraunt_id: int) -> Restaraunt:
         )
     return r
 
-@router.patch("/restaraunts/{restaraunt_id}/menu/{menu_id}")
+
+@router.post(
+    "/restaraunts/{restaraunt_id}/menu/{menu_id}",
+    status_code=status.HTTP_201_CREATED,
+    summary="Привязать меню к ресторану"
+)
 async def add_menu_to_rest(restaraunt_id: int, menu_id: int):
     result = await restaraunt.link_restaraunt_and_menu(restaraunt_id, menu_id)
     if result == "not_found":
@@ -30,4 +35,4 @@ async def add_menu_to_rest(restaraunt_id: int, menu_id: int):
         #связь уже есть(идемпотентно)
         return Response(status_code=204)
     all_menus = await menu.get_all_for_restaraunt(restaraunt_id)
-    return {"restaraunt_id": restaraunt_id, "menus": all_menus}
+    return {"status": "created", "restaraunt_id": restaraunt_id, "menus": all_menus}

--- a/src/restaraunts/endpoints/v1/restaraunt.py
+++ b/src/restaraunts/endpoints/v1/restaraunt.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, HTTPException, status, Response
 from src.restaraunts.schemas.restaraunt import Restaraunt
+from src.restaraunts.schemas.restarauntmenu import LinkMenuResponse
 from src.restaraunts.repo import restaraunt
 from src.restaraunts.repo import menu
 
@@ -25,14 +26,22 @@ async def get_restaraunt(restaraunt_id: int) -> Restaraunt:
 @router.post(
     "/restaraunts/{restaraunt_id}/menu/{menu_id}",
     status_code=status.HTTP_201_CREATED,
-    summary="Привязать меню к ресторану"
+    summary="Привязать меню к ресторану",
+    responses={204: {"model": None}}
 )
-async def add_menu_to_rest(restaraunt_id: int, menu_id: int):
+async def add_menu_to_rest(restaraunt_id: int, menu_id: int) -> LinkMenuResponse | Response:
     result = await restaraunt.link_restaraunt_and_menu(restaraunt_id, menu_id)
     if result == "not_found":
-        raise HTTPException(status_code=404, detail="Restaurant or Menu not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Restaraunt or Menu not found"
+        )
     if result == "already_exists":
         #связь уже есть(идемпотентно)
-        return Response(status_code=204)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
     all_menus = await menu.get_all_for_restaraunt(restaraunt_id)
-    return {"status": "created", "restaraunt_id": restaraunt_id, "menus": all_menus}
+    return LinkMenuResponse(
+        status="created",
+        restaraunt_id=restaraunt_id,
+        menus=all_menus
+    )

--- a/src/restaraunts/endpoints/v1/restaraunt.py
+++ b/src/restaraunts/endpoints/v1/restaraunt.py
@@ -1,22 +1,21 @@
 from fastapi import APIRouter, HTTPException, status
 from src.restaraunts.schemas.restaraunt import Restaraunt
-from src.restaraunts.repo.restaraunt import get_all, get_restaraunt
-import asyncio
+from src.restaraunts.repo import restaraunt
 
 router = APIRouter(tags=['restaraunts'])
 
 @router.get('/restaraunts')
 async def get_restaraunts() -> list[Restaraunt]:
-    restaraunts = await get_all()
+    restaraunts = await restaraunt.get_all()
     return restaraunts
 
 
 @router.get('/restaraunts/{restaraunt_id}')
 async def get_restaraunt(restaraunt_id: int) -> Restaraunt:
-    restaraunt = await get_restaraunt(restaraunt_id)
-    if restaraunt is None:
+    r = await restaraunt.get_restaraunt(restaraunt_id)
+    if r is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, 
             detail=f"Restaurant with id {restaraunt_id} not found"
         )
-    return restaraunt
+    return r

--- a/src/restaraunts/endpoints/v1/restaraunt.py
+++ b/src/restaraunts/endpoints/v1/restaraunt.py
@@ -1,4 +1,3 @@
-from typing import Any
 from fastapi import APIRouter, HTTPException, status, Response
 from src.restaraunts.schemas.restaraunt import Restaraunt
 from src.restaraunts.schemas.restarauntmenu import LinkMenuResponse
@@ -26,12 +25,11 @@ async def get_restaraunt(restaraunt_id: int) -> Restaraunt:
 
 @router.post(
     "/restaraunts/{restaraunt_id}/menu/{menu_id}",
-    response_model=LinkMenuResponse,
     status_code=status.HTTP_201_CREATED,
     summary="Привязать меню к ресторану",
     responses={204: {"model": None}}
 )
-async def add_menu_to_rest(restaraunt_id: int, menu_id: int) -> Any:
+async def add_menu_to_rest(restaraunt_id: int, menu_id: int) -> LinkMenuResponse:
     result = await restaraunt.link_restaraunt_and_menu(restaraunt_id, menu_id)
     if result == "not_found":
         raise HTTPException(

--- a/src/restaraunts/endpoints/v1/restaraunt.py
+++ b/src/restaraunts/endpoints/v1/restaraunt.py
@@ -19,3 +19,7 @@ async def get_restaraunt(restaraunt_id: int) -> Restaraunt:
             detail=f"Restaurant with id {restaraunt_id} not found"
         )
     return r
+
+@router.patch("/restaraunt/{restaraunt_id}/menu/{menu_id}")
+async def add_menu_to_rest(restaraunt_id: int, menu_id: int):
+    await restaraunt.link_restaurant_and_menu(restaraunt_id, menu_id)

--- a/src/restaraunts/repo/item.py
+++ b/src/restaraunts/repo/item.py
@@ -1,4 +1,5 @@
 from src.restaraunts.database import get_cursor
+from src.restaraunts.schemas.item import Item
 #import asyncio
 
 
@@ -29,13 +30,13 @@ async def init_db():
 #asyncio.run(init_db())
 
 
-async def add_item(name, price):
+async def add_item(name, price) -> int:
     async with get_cursor() as cursor:
         await cursor.execute('''
             INSERT INTO Items (name, price) 
             VALUES (?, ?)
         ''', (name, price))
-        print(f"Товар '{name}' добавлен. ID: {cursor.lastrowid}")
+        return cursor.lastrowid
 
 #asyncio.run(add_item("Кофе", 250))
 
@@ -48,23 +49,53 @@ async def delete_item(item_id: int):
         )
 
 
-async def get_all_items(show_archived=False):
+async def get_all(show_archived=False):
     """
     Получает список всех товаров.
     :param show_archived: Если True, вернет в том числе и 'удаленные' товары.
     """
     async with get_cursor() as cursor:
         if show_archived:
-            await cursor.execute("SELECT * FROM item")
+            await cursor.execute("SELECT * FROM Items")
         else:
-            await cursor.execute("SELECT * FROM item WHERE is_active = 1")
-    return [dict(row) for row in cursor.fetchall()]
+            await cursor.execute("SELECT * FROM Items WHERE is_active = 1")
+        rows = await cursor.fetchall()
+        return [Item(**dict(row)) for row in rows]
+
+
+async def get_all_for_menu(menu_id: int):
+    async with get_cursor() as cursor:
+        query = '''
+            SELECT i.* 
+            FROM Items i
+            JOIN MenuItems mi ON i.id = mi.item_id
+            WHERE mi.menu_id = ?
+        '''
+        await cursor.execute(query, (menu_id,))
+        rows = await cursor.fetchall()
+        return [Item(**dict(row)) for row in rows]
     
+
+async def get_item_for_menu(menu_id: int, item_id: int):
+    async with get_cursor() as cursor:
+        query = '''
+            SELECT i.* 
+            FROM Items i
+            JOIN MenuItems mi ON i.id = mi.item_id
+            WHERE mi.menu_id = ?
+            AND mi.item_id = ?
+         '''
+        await cursor.execute(query, (menu_id, item_id))
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        return Item(**dict(row))
+
 
 async def restore_item(item_id: int):
     """Восстанавливает ранее деактивированный товар."""
     async with get_cursor() as cursor:
         await cursor.execute(
-            "UPDATE item SET is_active = 1 WHERE id = ?",
+            "UPDATE Items SET is_active = 1 WHERE id = ?",
             (item_id,)
         )

--- a/src/restaraunts/repo/menu.py
+++ b/src/restaraunts/repo/menu.py
@@ -1,5 +1,6 @@
 from src.restaraunts.database import get_cursor
 from src.restaraunts.schemas.menu import Menu
+import sqlite3
 #import asyncio
 
 
@@ -37,8 +38,6 @@ async def add_menu(name: str) -> int:
         ''', (name,))
         return cursor.lastrowid
 
-#asyncio.run(add_menu('Сезонное'))
-
 
 async def get_all():
     async with get_cursor() as cursor:
@@ -74,3 +73,19 @@ async def get_menu_for_restaraunt(restaraunt_id: int, menu_id: int):
         if row is None:
             return None
         return Menu(**dict(row))
+    
+
+async def link_menu_and_iten(menu_id: int, item_id: int):
+    async with get_cursor() as cursor:
+        try:
+            await cursor.execute('''
+                INSERT INTO MenuItems (menu_id, item_id)
+                VALUES (?, ?)
+            ''', (menu_id, item_id))
+        except sqlite3.IntegrityError as e:
+            if "FOREIGN KEY constraint failed" in str(e):
+                return "not_found"
+            if "UNIQUE constraint failed" in str(e):
+                return "already_exists"
+            raise e
+        return "success"

--- a/src/restaraunts/repo/menu.py
+++ b/src/restaraunts/repo/menu.py
@@ -40,6 +40,13 @@ async def add_menu(name):
 #asyncio.run(add_menu('Сезонное'))
 
 
+async def get_all():
+    async with get_cursor() as cursor:
+        await cursor.execute("SELECT * FROM Menus")
+        rows = await cursor.fetchall() 
+        return [Menu(**dict(row)) for row in rows]
+
+
 async def get_all_for_restaraunt(restaraunt_id: int):
     async with get_cursor() as cursor:
         query = '''

--- a/src/restaraunts/repo/menu.py
+++ b/src/restaraunts/repo/menu.py
@@ -35,7 +35,6 @@ async def add_menu(name):
             INSERT INTO Menus (name) 
             VALUES (?)
         ''', (name,))
-        print(f"Меню '{name}' добавлено. ID: {cursor.lastrowid}")
 
 #asyncio.run(add_menu('Сезонное'))
 

--- a/src/restaraunts/repo/menu.py
+++ b/src/restaraunts/repo/menu.py
@@ -29,12 +29,13 @@ async def init_db():
 #asyncio.run(init_db())
 
 
-async def add_menu(name):
+async def add_menu(name: str) -> int:
     async with get_cursor() as cursor:
         await cursor.execute('''
             INSERT INTO Menus (name) 
             VALUES (?)
         ''', (name,))
+        return cursor.lastrowid
 
 #asyncio.run(add_menu('Сезонное'))
 

--- a/src/restaraunts/repo/menu.py
+++ b/src/restaraunts/repo/menu.py
@@ -40,7 +40,7 @@ async def add_menu(name):
 #asyncio.run(add_menu('Сезонное'))
 
 
-async def get_menus_for_restaraunt(restaraunt_id: int):
+async def get_all_for_restaraunt(restaraunt_id: int):
     async with get_cursor() as cursor:
         query = '''
             SELECT m.* 
@@ -51,3 +51,19 @@ async def get_menus_for_restaraunt(restaraunt_id: int):
         await cursor.execute(query, (restaraunt_id,))
         rows = await cursor.fetchall()
         return [Menu(**dict(row)) for row in rows]
+    
+
+async def get_menu_for_restaraunt(restaraunt_id: int, menu_id: int):
+    async with get_cursor() as cursor:
+        query = '''
+            SELECT m.* 
+            FROM Menus m
+            JOIN RestarauntMenus rm ON m.id = rm.menu_id
+            WHERE rm.restaraunt_id = ?
+            AND rm.menu_id = ?
+        '''
+        await cursor.execute(query, (restaraunt_id, menu_id))
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        return Menu(**dict(row))

--- a/src/restaraunts/repo/order.py
+++ b/src/restaraunts/repo/order.py
@@ -40,13 +40,16 @@ async def add_order(price, restaraunt_id):
         return cursor.lastrowid
 
 
-async def update_order_status(order_id, new_status):
+async def update_status(order_id, new_status):
     async with get_cursor() as cursor:
         await cursor.execute('''
             UPDATE Orders
             SET "status" = ?
             WHERE id = ?
+            RETURNING *
         ''', (new_status, order_id))
+        row = await cursor.fetchone() 
+        return Order(**dict(row))
 
 
 async def get_all_for_restaraunt(restaraunt_id: int):

--- a/src/restaraunts/repo/order.py
+++ b/src/restaraunts/repo/order.py
@@ -10,7 +10,7 @@ async def init_db():
             id INTEGER PRIMARY KEY,
             created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            "status" TEXT NOT NULL DEFAULT 'Новый',
+            "status" TEXT DEFAULT 'Новый' NOT NULL,
             price REAL NOT NULL,
             restaraunt_id INTEGER,
             FOREIGN KEY (restaraunt_id) REFERENCES Restaraunts(id) ON DELETE RESTRICT
@@ -19,7 +19,7 @@ async def init_db():
 
 
         #Триггер для автоматического обновления updated_at
-        await cursor.executecursor.execute('''
+        await cursor.execute('''
         CREATE TRIGGER IF NOT EXISTS update_Orders_updated_at
         AFTER UPDATE ON Orders
         FOR EACH ROW
@@ -31,12 +31,12 @@ async def init_db():
 #asyncio.run(init_db())
 
 
-async def add_order(status, price, restaraunt_id):
+async def add_order(price, restaraunt_id):
     async with get_cursor() as cursor:
         await cursor.execute('''
-            INSERT INTO Orders ("status", price, restaraunt_id)
-            VALUES (?, ?, ?)
-        ''', (status, price, restaraunt_id))
+            INSERT INTO Orders (price, restaraunt_id)
+            VALUES (?, ?)
+        ''', (price, restaraunt_id))
         return cursor.lastrowid
 
 

--- a/src/restaraunts/repo/order.py
+++ b/src/restaraunts/repo/order.py
@@ -1,4 +1,5 @@
 from src.restaraunts.database import get_cursor
+from src.restaraunts.schemas.order import Order
 #import asyncio
 
 
@@ -46,3 +47,28 @@ async def update_order_status(order_id, new_status):
             SET "status" = ?
             WHERE id = ?
         ''', (new_status, order_id))
+
+
+async def get_all_for_restaraunt(restaraunt_id: int):
+    async with get_cursor() as cursor:
+        await cursor.execute('''
+            SELECT * 
+            FROM Orders
+            WHERE restaraunt_id = ?
+        ''', (restaraunt_id,))
+        rows = await cursor.fetchall()
+        return [Order(**dict(row)) for row in rows]
+    
+
+async def get_order_for_restaraunt(restaraunt_id: int, order_id: int):
+    async with get_cursor() as cursor:
+        await cursor.execute('''
+            SELECT * 
+            FROM Orders
+            WHERE restaraunt_id = ?
+            AND id = ?
+        ''', (restaraunt_id, order_id))
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        return Order(**dict(row))

--- a/src/restaraunts/repo/restaraunt.py
+++ b/src/restaraunts/repo/restaraunt.py
@@ -1,5 +1,6 @@
 from src.restaraunts.database import get_cursor
 from src.restaraunts.schemas.restaraunt import Restaraunt
+import sqlite3
 #import asyncio
 
 async def init_db():
@@ -58,9 +59,17 @@ async def add_restaraunt(name):
 #asyncio.run(add_restaraunt('Пхали'))
 
 
-async def link_restaurant_and_menu(restaurant_id: int, menu_id: int):
+async def link_restaraunt_and_menu(restaraunt_id: int, menu_id: int):
     async with get_cursor() as cursor:
-        await cursor.execute('''
-            INSERT OR IGNORE INTO RestarauntMenus (restaraunt_id, menu_id)
-            VALUES (?, ?)
-        ''', (restaurant_id, menu_id))
+        try:
+            await cursor.execute('''
+                INSERT INTO RestarauntMenus (restaraunt_id, menu_id)
+                VALUES (?, ?)
+            ''', (restaraunt_id, menu_id))
+        except sqlite3.IntegrityError as e:
+            if "FOREIGN KEY constraint failed" in str(e):
+                return "not_found"
+            if "UNIQUE constraint failed" in str(e):
+                return "already_exists"
+            raise e
+        return "success"

--- a/src/restaraunts/repo/restaraunt.py
+++ b/src/restaraunts/repo/restaraunt.py
@@ -56,3 +56,11 @@ async def add_restaraunt(name):
         print(f"Ресторан '{name}' добавлен. ID: {cursor.lastrowid}")
 
 #asyncio.run(add_restaraunt('Пхали'))
+
+
+async def link_restaurant_and_menu(restaurant_id: int, menu_id: int):
+    async with get_cursor() as cursor:
+        await cursor.execute('''
+            INSERT OR IGNORE INTO RestarauntMenus (restaraunt_id, menu_id)
+            VALUES (?, ?)
+        ''', (restaurant_id, menu_id))

--- a/src/restaraunts/repo/restaraunt.py
+++ b/src/restaraunts/repo/restaraunt.py
@@ -73,3 +73,4 @@ async def link_restaraunt_and_menu(restaraunt_id: int, menu_id: int):
                 return "already_exists"
             raise e
         return "success"
+    

--- a/src/restaraunts/repo/restarauntmenu.py
+++ b/src/restaraunts/repo/restarauntmenu.py
@@ -30,12 +30,3 @@ async def init_db():
 #asyncio.run(init_db())
 
 
-async def add_restarauntmenu(restaraunt_id, menu_id):
-    async with get_cursor() as cursor:
-        await cursor.execute('''
-            INSERT INTO RestarauntMenus (restaraunt_id, menu_id) 
-            VALUES (?, ?)
-        ''', (restaraunt_id, menu_id))
-        print(f"Меню с ID: '{menu_id}' добавлено к ресторану с ID: '{restaraunt_id}'")
-
-#asyncio.run(add_restarauntmenu(2, 1))

--- a/src/restaraunts/schemas/item.py
+++ b/src/restaraunts/schemas/item.py
@@ -1,7 +1,15 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from src.restaraunts.schemas.base import Base
 
-class Item(Base):
-    price: int
-    name: str
+class ItemCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100, example="Пиво")
+    price: float = Field(gt=0)
+
+class Item(Base, ItemCreate):
+    is_active: bool
     
+class ItemResponse(BaseModel):
+    id: int
+    name: str
+    price: float
+    status: str = "created"

--- a/src/restaraunts/schemas/menu.py
+++ b/src/restaraunts/schemas/menu.py
@@ -1,10 +1,8 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from src.restaraunts.schemas.base import Base
 
 class MenuCreate(BaseModel):
-    version: int
-    name: str
+    name: str = Field(..., min_length=1, max_length=100, example="Летнее меню")
 
 class Menu(Base, MenuCreate):
-    pass
-
+    version: int

--- a/src/restaraunts/schemas/menu.py
+++ b/src/restaraunts/schemas/menu.py
@@ -6,3 +6,8 @@ class MenuCreate(BaseModel):
 
 class Menu(Base, MenuCreate):
     version: int
+
+class MenuResponse(BaseModel):
+    id: int
+    name: str
+    status: str = "created"

--- a/src/restaraunts/schemas/menuitem.py
+++ b/src/restaraunts/schemas/menuitem.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, ConfigDict
+
+class MenuItemEntry(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+
+class LinkItemResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    status: str = "created"
+    menu_id: int
+    items: list[MenuItemEntry]

--- a/src/restaraunts/schemas/order.py
+++ b/src/restaraunts/schemas/order.py
@@ -1,11 +1,10 @@
 from .base import Base
-from src.restaraunts.schemas.ordereditem import OrderedItem
 import enum
 
 class Order(Base):
-    ordereditems: list[OrderedItem]
     status: OrderStatus
-    price: int
+    price: float
+    restaraunt_id: int
 
 
 class OrderStatus(enum.StrEnum):

--- a/src/restaraunts/schemas/order.py
+++ b/src/restaraunts/schemas/order.py
@@ -1,9 +1,20 @@
+from pydantic import BaseModel, Field
 from .base import Base
 import enum
 
-class Order(Base):
-    status: OrderStatus
+class OrderCreate(BaseModel):
+    price: float = Field(gt=0)
+
+
+class OrderResponse(BaseModel):
+    id: int
     price: float
+    restaraunt_id: int
+    status: str = "Новый"
+
+
+class Order(Base, OrderCreate):
+    status: OrderStatus
     restaraunt_id: int
 
 

--- a/src/restaraunts/schemas/order.py
+++ b/src/restaraunts/schemas/order.py
@@ -18,8 +18,12 @@ class Order(Base, OrderCreate):
     restaraunt_id: int
 
 
-class OrderStatus(enum.StrEnum):
+class OrderStatus(str, enum.Enum):
     NEW = 'Новый'
     COMPLETED = 'Сформирован'
     READY = 'Готов'
     PAID = 'Оплачен'
+
+
+class OrderStatusUpdate(BaseModel):
+    new_status: OrderStatus 

--- a/src/restaraunts/schemas/ordereditem.py
+++ b/src/restaraunts/schemas/ordereditem.py
@@ -1,12 +1,11 @@
-from pydantic import BaseModel
-from src.restaraunts.schemas.item import Item
 from src.restaraunts.schemas.base import Base
 import enum
 
 class OrderedItem(Base):
-    item: Item
+    item_id: str
     status: OrderedItemStatus
-    price: int
+    price: float
+    order_id: str
 
 
 class OrderedItemStatus(enum.StrEnum):

--- a/src/restaraunts/schemas/restaraunt.py
+++ b/src/restaraunts/schemas/restaraunt.py
@@ -1,9 +1,4 @@
 from src.restaraunts.schemas.base import Base
-from src.restaraunts.schemas.menu import Menu
-from src.restaraunts.schemas.order import Order
-from typing import List, Optional
 
 class Restaraunt(Base):
     name: str
-    menus: List[Optional[Menu]] = [] 
-    orders: List[Optional[Order]] = []

--- a/src/restaraunts/schemas/restarauntmenu.py
+++ b/src/restaraunts/schemas/restarauntmenu.py
@@ -1,10 +1,14 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 class RestaurantMenuEntry(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     name: str
 
 class LinkMenuResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     status: str = "created"
     restaraunt_id: int
     menus: list[RestaurantMenuEntry]

--- a/src/restaraunts/schemas/restarauntmenu.py
+++ b/src/restaraunts/schemas/restarauntmenu.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+class RestaurantMenuEntry(BaseModel):
+    id: int
+    name: str
+
+class LinkMenuResponse(BaseModel):
+    status: str = "created"
+    restaraunt_id: int
+    menus: list[RestaurantMenuEntry]


### PR DESCRIPTION
Все эндпоинты приведены к единому корневому префиксу /restaraunts.
Удалены неиспользуемые поля в моделях Pydantic (в соответствии с получаемыми данными из БД).

Реализованы новые эндпоинты для:
Получения общего списка всех меню.
Получения списка меню, привязанных к конкретному ресторану.
Создания меню через POST (с последующим переносом параметров из Query-строки в тело запроса).
Создания связи между рестораном и меню, с обработкой IntegrityError на уровне базы данных для проверки существования id, с возможностью возвращать различные статусы в зависимости от результата (201 Created при создании и 204 No Content при повторном вызове).

Добавлены аннотации типов и summary к эндпоинтам.