### PR TITLE
Implement SQLAlchemy ORM foundation and finalize V1 endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 *.bkp
 *.db
+/.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:system"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python-envs.defaultEnvManager": "ms-python.python:system"
-}

--- a/poetry.lock
+++ b/poetry.lock
@@ -59,6 +59,132 @@ idna = ">=2.8"
 trio = ["trio (>=0.31.0) ; python_version < \"3.10\"", "trio (>=0.32.0) ; python_version >= \"3.10\""]
 
 [[package]]
+name = "authlib"
+version = "1.7.0"
+description = "The ultimate Python library in building OAuth and OpenID Connect servers and clients."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0"},
+    {file = "authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5"},
+]
+
+[package.dependencies]
+cryptography = "*"
+joserfc = ">=1.6.0"
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+description = "Python package for providing Mozilla's CA Bundle."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"},
+    {file = "certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580"},
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "platform_python_implementation != \"PyPy\""
+files = [
+    {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
+    {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb"},
+    {file = "cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a"},
+    {file = "cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743"},
+    {file = "cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187"},
+    {file = "cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18"},
+    {file = "cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5"},
+    {file = "cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b"},
+    {file = "cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27"},
+    {file = "cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75"},
+    {file = "cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1"},
+    {file = "cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f"},
+    {file = "cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25"},
+    {file = "cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4"},
+    {file = "cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322"},
+    {file = "cffi-2.0.0-cp39-cp39-win32.whl", hash = "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a"},
+    {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
+    {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
+]
+
+[package.dependencies]
+pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
+
+[[package]]
 name = "click"
 version = "8.3.1"
 description = "Composable command line interface toolkit"
@@ -85,6 +211,78 @@ files = [
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
 markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
+
+[[package]]
+name = "cryptography"
+version = "46.0.7"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = "!=3.9.0,!=3.9.1,>=3.8"
+groups = ["main"]
+files = [
+    {file = "cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b"},
+    {file = "cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85"},
+    {file = "cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e"},
+    {file = "cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457"},
+    {file = "cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b"},
+    {file = "cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2"},
+    {file = "cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e"},
+    {file = "cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee"},
+    {file = "cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298"},
+    {file = "cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb"},
+    {file = "cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0"},
+    {file = "cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85"},
+    {file = "cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e"},
+    {file = "cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246"},
+    {file = "cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4"},
+    {file = "cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5"},
+]
+
+[package.dependencies]
+cffi = {version = ">=2.0.0", markers = "python_full_version >= \"3.9.0\" and platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs", "sphinx-rtd-theme (>=3.0.0)"]
+docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
+nox = ["nox[uv] (>=2024.4.15)"]
+pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.14)", "ruff (>=0.11.11)"]
+sdist = ["build (>=1.0.0)"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==46.0.7)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "fastapi"
@@ -197,6 +395,53 @@ files = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.9"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.16"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+httpcore = "==1.*"
+idna = "*"
+
+[package.extras]
+brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
 name = "idna"
 version = "3.11"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -222,6 +467,24 @@ files = [
     {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
     {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
 ]
+
+[[package]]
+name = "joserfc"
+version = "1.6.4"
+description = "The ultimate Python library for JOSE RFCs, including JWS, JWE, JWK, JWA, JWT"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a"},
+    {file = "joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c"},
+]
+
+[package.dependencies]
+cryptography = ">=45.0.1"
+
+[package.extras]
+drafts = ["pycryptodome"]
 
 [[package]]
 name = "packaging"
@@ -250,6 +513,19 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+description = "C parser in Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
+files = [
+    {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
+    {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
+]
 
 [[package]]
 name = "pydantic"
@@ -613,4 +889,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.14"
-content-hash = "60ebbd9f8c09ced42a3aded1d088b5a04394d7cd500a17602d639be57f633ee0"
+content-hash = "4a7d796c322db44d3fcf9edee4d9bb69678bc109d3f308c368cc3aafbb1e0390"

--- a/poetry.lock
+++ b/poetry.lock
@@ -111,6 +111,80 @@ standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "htt
 standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[standard-no-fastapi-cloud-cli] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
+name = "greenlet"
+version = "3.4.0"
+description = "Lightweight in-process concurrent programming"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""
+files = [
+    {file = "greenlet-3.4.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:d18eae9a7fb0f499efcd146b8c9750a2e1f6e0e93b5a382b3481875354a430e6"},
+    {file = "greenlet-3.4.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:636d2f95c309e35f650e421c23297d5011716be15d966e6328b367c9fc513a82"},
+    {file = "greenlet-3.4.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:234582c20af9742583c3b2ddfbdbb58a756cfff803763ffaae1ac7990a9fac31"},
+    {file = "greenlet-3.4.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ac6a5f618be581e1e0713aecec8e54093c235e5fa17d6d8eb7ffc487e2300508"},
+    {file = "greenlet-3.4.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:523677e69cd4711b5a014e37bc1fb3a29947c3e3a5bb6a527e1cc50312e5a398"},
+    {file = "greenlet-3.4.0-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:d336d46878e486de7d9458653c722875547ac8d36a1cff9ffaf4a74a3c1f62eb"},
+    {file = "greenlet-3.4.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b45e45fe47a19051a396abb22e19e7836a59ee6c5a90f3be427343c37908d65b"},
+    {file = "greenlet-3.4.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5434271357be07f3ad0936c312645853b7e689e679e29310e2de09a9ea6c3adf"},
+    {file = "greenlet-3.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:a19093fbad824ed7c0f355b5ff4214bffda5f1a7f35f29b31fcaa240cc0135ab"},
+    {file = "greenlet-3.4.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:805bebb4945094acbab757d34d6e1098be6de8966009ab9ca54f06ff492def58"},
+    {file = "greenlet-3.4.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:439fc2f12b9b512d9dfa681c5afe5f6b3232c708d13e6f02c845e0d9f4c2d8c6"},
+    {file = "greenlet-3.4.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a70ed1cb0295bee1df57b63bf7f46b4e56a5c93709eea769c1fec1bb23a95875"},
+    {file = "greenlet-3.4.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c5696c42e6bb5cfb7c6ff4453789081c66b9b91f061e5e9367fa15792644e76"},
+    {file = "greenlet-3.4.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c660bce1940a1acae5f51f0a064f1bc785d07ea16efcb4bc708090afc4d69e83"},
+    {file = "greenlet-3.4.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:89995ce5ddcd2896d89615116dd39b9703bfa0c07b583b85b89bf1b5d6eddf81"},
+    {file = "greenlet-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ee407d4d1ca9dc632265aee1c8732c4a2d60adff848057cdebfe5fe94eb2c8a2"},
+    {file = "greenlet-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:956215d5e355fffa7c021d168728321fd4d31fd730ac609b1653b450f6a4bc71"},
+    {file = "greenlet-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:5cb614ace7c27571270354e9c9f696554d073f8aa9319079dcba466bbdead711"},
+    {file = "greenlet-3.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:04403ac74fe295a361f650818de93be11b5038a78f49ccfb64d3b1be8fbf1267"},
+    {file = "greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a"},
+    {file = "greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97"},
+    {file = "greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996"},
+    {file = "greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d"},
+    {file = "greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc"},
+    {file = "greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077"},
+    {file = "greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de"},
+    {file = "greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08"},
+    {file = "greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2"},
+    {file = "greenlet-3.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:f38b81880ba28f232f1f675893a39cf7b6db25b31cc0a09bb50787ecf957e85e"},
+    {file = "greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1"},
+    {file = "greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1"},
+    {file = "greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82"},
+    {file = "greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f"},
+    {file = "greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf"},
+    {file = "greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55"},
+    {file = "greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729"},
+    {file = "greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c"},
+    {file = "greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940"},
+    {file = "greenlet-3.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:9390ad88b652b1903814eaabd629ca184db15e0eeb6fe8a390bbf8b9106ae15a"},
+    {file = "greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e"},
+    {file = "greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d"},
+    {file = "greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615"},
+    {file = "greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19"},
+    {file = "greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf"},
+    {file = "greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd"},
+    {file = "greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf"},
+    {file = "greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda"},
+    {file = "greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d"},
+    {file = "greenlet-3.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:f8296d4e2b92af34ebde81085a01690f26a51eb9ac09a0fcadb331eb36dbc802"},
+    {file = "greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece"},
+    {file = "greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8"},
+    {file = "greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2"},
+    {file = "greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa"},
+    {file = "greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed"},
+    {file = "greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72"},
+    {file = "greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f"},
+    {file = "greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a"},
+    {file = "greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705"},
+    {file = "greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff"},
+]
+
+[package.extras]
+docs = ["Sphinx", "furo"]
+test = ["objgraph", "psutil", "setuptools"]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -371,6 +445,108 @@ pygments = ">=2.7.2"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+description = "Database Abstraction Library"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "sqlalchemy-2.0.49-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:42e8804962f9e6f4be2cbaedc0c3718f08f60a16910fa3d86da5a1e3b1bfe60f"},
+    {file = "sqlalchemy-2.0.49-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc992c6ed024c8c3c592c5fc9846a03dd68a425674900c70122c77ea16c5fb0b"},
+    {file = "sqlalchemy-2.0.49-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6eb188b84269f357669b62cb576b5b918de10fb7c728a005fa0ebb0b758adce1"},
+    {file = "sqlalchemy-2.0.49-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:62557958002b69699bdb7f5137c6714ca1133f045f97b3903964f47db97ea339"},
+    {file = "sqlalchemy-2.0.49-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:da9b91bca419dc9b9267ffadde24eae9b1a6bffcd09d0a207e5e3af99a03ce0d"},
+    {file = "sqlalchemy-2.0.49-cp310-cp310-win32.whl", hash = "sha256:5e61abbec255be7b122aa461021daa7c3f310f3e743411a67079f9b3cc91ece3"},
+    {file = "sqlalchemy-2.0.49-cp310-cp310-win_amd64.whl", hash = "sha256:0c98c59075b890df8abfcc6ad632879540f5791c68baebacb4f833713b510e75"},
+    {file = "sqlalchemy-2.0.49-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c5070135e1b7409c4161133aa525419b0062088ed77c92b1da95366ec5cbebbe"},
+    {file = "sqlalchemy-2.0.49-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ac7a3e245fd0310fd31495eb61af772e637bdf7d88ee81e7f10a3f271bff014"},
+    {file = "sqlalchemy-2.0.49-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d4e5a0ceba319942fa6b585cf82539288a61e314ef006c1209f734551ab9536"},
+    {file = "sqlalchemy-2.0.49-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3ddcb27fb39171de36e207600116ac9dfd4ae46f86c82a9bf3934043e80ebb88"},
+    {file = "sqlalchemy-2.0.49-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:32fe6a41ad97302db2931f05bb91abbcc65b5ce4c675cd44b972428dd2947700"},
+    {file = "sqlalchemy-2.0.49-cp311-cp311-win32.whl", hash = "sha256:46d51518d53edfbe0563662c96954dc8fcace9832332b914375f45a99b77cc9a"},
+    {file = "sqlalchemy-2.0.49-cp311-cp311-win_amd64.whl", hash = "sha256:951d4a210744813be63019f3df343bf233b7432aadf0db54c75802247330d3af"},
+    {file = "sqlalchemy-2.0.49-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbccb45260e4ff1b7db0be80a9025bb1e6698bdb808b83fff0000f7a90b2c0b"},
+    {file = "sqlalchemy-2.0.49-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb37f15714ec2652d574f021d479e78cd4eb9d04396dca36568fdfffb3487982"},
+    {file = "sqlalchemy-2.0.49-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3bb9ec6436a820a4c006aad1ac351f12de2f2dbdaad171692ee457a02429b672"},
+    {file = "sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8d6efc136f44a7e8bc8088507eaabbb8c2b55b3dbb63fe102c690da0ddebe55e"},
+    {file = "sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e06e617e3d4fd9e51d385dfe45b077a41e9d1b033a7702551e3278ac597dc750"},
+    {file = "sqlalchemy-2.0.49-cp312-cp312-win32.whl", hash = "sha256:83101a6930332b87653886c01d1ee7e294b1fe46a07dd9a2d2b4f91bcc88eec0"},
+    {file = "sqlalchemy-2.0.49-cp312-cp312-win_amd64.whl", hash = "sha256:618a308215b6cececb6240b9abde545e3acdabac7ae3e1d4e666896bf5ba44b4"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7"},
+    {file = "sqlalchemy-2.0.49-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8a97ac839c2c6672c4865e48f3cbad7152cee85f4233fb4ca6291d775b9b954a"},
+    {file = "sqlalchemy-2.0.49-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c338ec6ec01c0bc8e735c58b9f5d51e75bacb6ff23296658826d7cfdfdb8678a"},
+    {file = "sqlalchemy-2.0.49-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:566df36fd0e901625523a5a1835032f1ebdd7f7886c54584143fa6c668b4df3b"},
+    {file = "sqlalchemy-2.0.49-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:d99945830a6f3e9638d89a28ed130b1eb24c91255e4f24366fbe699b983f29e4"},
+    {file = "sqlalchemy-2.0.49-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:01146546d84185f12721a1d2ce0c6673451a7894d1460b592d378ca4871a0c72"},
+    {file = "sqlalchemy-2.0.49-cp38-cp38-win32.whl", hash = "sha256:69469ce8ce7a8df4d37620e3163b71238719e1e2e5048d114a1b6ce0fbf8c662"},
+    {file = "sqlalchemy-2.0.49-cp38-cp38-win_amd64.whl", hash = "sha256:b95b2f470c1b2683febd2e7eab1d3f0e078c91dbdd0b00e9c645d07a413bb99f"},
+    {file = "sqlalchemy-2.0.49-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:43d044780732d9e0381ac8d5316f95d7f02ef04d6e4ef6dc82379f09795d993f"},
+    {file = "sqlalchemy-2.0.49-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d6be30b2a75362325176c036d7fb8d19e8846c77e87683ffaa8177b35135613"},
+    {file = "sqlalchemy-2.0.49-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d898cc2c76c135ef65517f4ddd7a3512fb41f23087b0650efb3418b8389a3cd1"},
+    {file = "sqlalchemy-2.0.49-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:059d7151fff513c53a4638da8778be7fce81a0c4854c7348ebd0c4078ddf28fe"},
+    {file = "sqlalchemy-2.0.49-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:334edbcff10514ad1d66e3a70b339c0a29886394892490119dbb669627b17717"},
+    {file = "sqlalchemy-2.0.49-cp39-cp39-win32.whl", hash = "sha256:74ab4ee7794d7ed1b0c37e7333640e0f0a626fc7b398c07a7aef52f484fddde3"},
+    {file = "sqlalchemy-2.0.49-cp39-cp39-win_amd64.whl", hash = "sha256:88690f4e1f0fbf5339bedbb127e240fec1fd3070e9934c0b7bef83432f779d2f"},
+    {file = "sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0"},
+    {file = "sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f"},
+]
+
+[package.dependencies]
+greenlet = {version = ">=1", markers = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""}
+typing-extensions = ">=4.6.0"
+
+[package.extras]
+aiomysql = ["aiomysql (>=0.2.0)", "greenlet (>=1)"]
+aioodbc = ["aioodbc", "greenlet (>=1)"]
+aiosqlite = ["aiosqlite", "greenlet (>=1)", "typing_extensions (!=3.10.0.1)"]
+asyncio = ["greenlet (>=1)"]
+asyncmy = ["asyncmy (>=0.2.3,!=0.2.4,!=0.2.6)", "greenlet (>=1)"]
+mariadb-connector = ["mariadb (>=1.0.1,!=1.1.2,!=1.1.5,!=1.1.10)"]
+mssql = ["pyodbc"]
+mssql-pymssql = ["pymssql"]
+mssql-pyodbc = ["pyodbc"]
+mypy = ["mypy (>=0.910)"]
+mysql = ["mysqlclient (>=1.4.0)"]
+mysql-connector = ["mysql-connector-python"]
+oracle = ["cx_oracle (>=8)"]
+oracle-oracledb = ["oracledb (>=1.0.1)"]
+postgresql = ["psycopg2 (>=2.7)"]
+postgresql-asyncpg = ["asyncpg", "greenlet (>=1)"]
+postgresql-pg8000 = ["pg8000 (>=1.29.1)"]
+postgresql-psycopg = ["psycopg (>=3.0.7)"]
+postgresql-psycopg2binary = ["psycopg2-binary"]
+postgresql-psycopg2cffi = ["psycopg2cffi"]
+postgresql-psycopgbinary = ["psycopg[binary] (>=3.0.7)"]
+pymysql = ["pymysql"]
+sqlcipher = ["sqlcipher3_binary"]
+
+[[package]]
 name = "starlette"
 version = "0.50.0"
 description = "The little ASGI library that shines."
@@ -437,4 +613,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.14"
-content-hash = "01a25263a2969be99b86e3a70a114c806e696437e6ba2e566d18e3222a92ba50"
+content-hash = "60ebbd9f8c09ced42a3aded1d088b5a04394d7cd500a17602d639be57f633ee0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ dependencies = [
     "uvicorn (>=0.40.0,<0.41.0)",
     "pydantic (>=2.12.5,<3.0.0)",
     "aiosqlite (>=0.22.1,<0.23.0)",
-    "sqlalchemy (>=2.0.49,<3.0.0)"
+    "sqlalchemy (>=2.0.49,<3.0.0)",
+    "authlib (>=1.7.0,<2.0.0)",
+    "httpx (>=0.28.1,<0.29.0)"
 ]
 
 [tool.poetry]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
     "fastapi (>=0.128.0,<0.129.0)",
     "uvicorn (>=0.40.0,<0.41.0)",
     "pydantic (>=2.12.5,<3.0.0)",
-    "aiosqlite (>=0.22.1,<0.23.0)"
+    "aiosqlite (>=0.22.1,<0.23.0)",
+    "sqlalchemy (>=2.0.49,<3.0.0)"
 ]
 
 [tool.poetry]

--- a/src/restaraunts/auth/deps.py
+++ b/src/restaraunts/auth/deps.py
@@ -1,0 +1,16 @@
+from typing import Annotated
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi import Depends
+from .oidc import OIDCClient
+
+
+bearer_token_schema = HTTPBearer()
+oidc = OIDCClient(issuer="https://lemur-16.cloud-iam.com/auth/realms/my-fastapi-auth", client_id="fastapi-client")
+
+async def get_valid_token(token: HTTPAuthorizationCredentials = Depends(bearer_token_schema)) -> str:
+    _token = token.credentials
+    await oidc.validate_token(_token)
+    return _token
+    
+
+AuthTokenDep = Annotated[str, Depends(get_valid_token)]

--- a/src/restaraunts/auth/oidc.py
+++ b/src/restaraunts/auth/oidc.py
@@ -1,0 +1,38 @@
+import httpx
+from authlib.jose import JsonWebToken
+
+class OIDCClient:
+    def __init__(self, issuer: str, client_id: str):
+        self.issuer = issuer
+        self.client_id = client_id
+        self.jwt = JsonWebToken(['RS256', 'RS512'])
+        self.jwks = {}
+
+    async def get_jwks(self) -> dict:
+        if self.jwks:
+            return self.jwks
+        async with httpx.AsyncClient() as client:
+            metadata_r = await client.get(f'{self.issuer}/.well-known/openid-configuration')
+            metadata_r.raise_for_status()
+            metadata = metadata_r.json()
+            jwks_r = await client.get(f'{metadata.get('jwks_uri')}')
+            jwks_r.raise_for_status()
+            jwks = jwks_r.json()
+            self.jwks = jwks
+            return jwks
+
+
+    async def validate_token(self, token: str) -> dict:
+        jwks = await self.get_jwks()
+        try:
+            options = {
+                "iss": {"essential": True, "values": [self.issuer]},
+                "azp": {"essential": True, "values": [self.client_id]}
+            }
+            claims = self.jwt.decode(token, jwks, claims_options=options)
+            claims.validate()
+            return claims
+        except Exception as e:
+            print(f"Token validation failed: {e}")
+            raise e
+    

--- a/src/restaraunts/config.py
+++ b/src/restaraunts/config.py
@@ -5,3 +5,4 @@ from pathlib import Path
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 DB_PATH = BASE_DIR / "data" / "restaraunts.db" 
+DB_PATH_V2 = BASE_DIR / "data" / "restaraunts_v2.db"

--- a/src/restaraunts/database.py
+++ b/src/restaraunts/database.py
@@ -1,13 +1,10 @@
 import sqlite3
 import aiosqlite
-from src.restaraunts.config import DB_PATH
+from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession, create_async_engine
+from sqlalchemy import text, event
+from src.restaraunts.config import DB_PATH, DB_PATH_V2
 from contextlib import asynccontextmanager
 
-# def get_connection():
-#     conn = sqlite3.connect(DB_PATH)
-#     conn.row_factory = sqlite3.Row  
-#     conn.execute("PRAGMA foreign_keys = ON") 
-#     return conn
 
 @asynccontextmanager
 async def get_cursor():
@@ -23,3 +20,34 @@ async def get_cursor():
         raise e
     finally:
         await conn.close()
+
+
+DATABASE_URL = f"sqlite+aiosqlite:///{DB_PATH_V2}"
+
+engine = create_async_engine(DATABASE_URL, echo=True)
+
+
+@event.listens_for(engine.sync_engine, "connect")
+def set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+async_session_factory = async_sessionmaker(
+    bind=engine, 
+    class_=AsyncSession,
+    expire_on_commit=False
+)
+
+
+async def get_db():
+    async with async_session_factory() as session:
+        yield session
+
+
+async def test_conn():
+    async with async_session_factory() as session:
+        async with session.begin():
+            result = await session.execute(text("SELECT 'session is working'"))
+            print(result.scalar())

--- a/src/restaraunts/database.py
+++ b/src/restaraunts/database.py
@@ -1,5 +1,6 @@
 import sqlite3
 import aiosqlite
+from typing import AsyncGenerator
 from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession, create_async_engine
 from sqlalchemy import text, event
 from src.restaraunts.config import DB_PATH, DB_PATH_V2
@@ -41,9 +42,16 @@ async_session_factory = async_sessionmaker(
 )
 
 
-async def get_db():
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
     async with async_session_factory() as session:
-        yield session
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await session.close()
 
 
 async def test_conn():

--- a/src/restaraunts/endpoints/__init__.py
+++ b/src/restaraunts/endpoints/__init__.py
@@ -1,8 +1,16 @@
 from fastapi import APIRouter
 from .v1 import menu, restaraunt, order, item
+from .v2 import menu as menu_v2, restaraunt as restaraunt_v2, order as order_v2, item as item_v2
+
 
 v1_router = APIRouter(prefix="/v1")
-v1_router.include_router(menu.router)
-v1_router.include_router(item.router)
-v1_router.include_router(restaraunt.router)
-v1_router.include_router(order.router)
+v1_router.include_router(menu.router, tags=["v1 | menu"])
+v1_router.include_router(item.router, tags=["v1 | item"])
+v1_router.include_router(restaraunt.router, tags=["v1 | restaraunt"])
+v1_router.include_router(order.router, tags=["v1 | order"])
+
+v2_router = APIRouter(prefix="/v2")
+v2_router.include_router(menu_v2.router, tags=["v2 (ORM) | menu"])
+v2_router.include_router(item_v2.router, tags=["v2 (ORM) | item"])
+v2_router.include_router(restaraunt_v2.router, tags=["v2 (ORM) | restaraunt"])
+v2_router.include_router(order_v2.router, tags=["v2 (ORM) | order"])

--- a/src/restaraunts/endpoints/v1/item.py
+++ b/src/restaraunts/endpoints/v1/item.py
@@ -2,23 +2,22 @@ from fastapi import APIRouter, status, HTTPException, Response
 from src.restaraunts.repo import item, ordereditem
 from src.restaraunts.schemas.item import Item, ItemCreate, ItemResponse
 from src.restaraunts.schemas.ordereditem import OrderedItem, OrderedItemStatus, OrderedItemResponse, OrderedItemStatusUpdate
+from typing import List
 
 router = APIRouter()
 
 
 @router.get('/restaraunts/items', summary="Получить список всех товаров")
-async def get_all() -> list[Item]:
-    items = await item.get_all()
-    return items
+async def get_all() -> List[Item]:
+    return await item.get_all()
 
 
 @router.get(
     '/restaraunts/{restaraunt_id}/menu/{menu_id}/items',
     summary="Получить список всех товаров (для меню)"
 )
-async def get_all_for_m(menu_id: int) -> list[Item]:
-    items= await item.get_all_for_menu(menu_id)
-    return items
+async def get_all_for_m(menu_id: int) -> List[Item]:
+    return await item.get_all_for_menu(menu_id)
 
 
 @router.get(
@@ -26,8 +25,7 @@ async def get_all_for_m(menu_id: int) -> list[Item]:
     summary="Получить детальную информацию о товаре (для меню)"
 )
 async def get_item(menu_id: int, item_id: int) -> Item:
-    i = await item.get_item_for_menu(menu_id, item_id)
-    return i
+    return await item.get_item_for_menu(menu_id, item_id)
    
 
 @router.post(
@@ -45,13 +43,12 @@ async def create_item(item_data: ItemCreate) -> ItemResponse:
     )
 
 
-@router.patch(
-    '/restaraunts/items/{item_id}/deactivate',
+@router.delete(
+    '/restaraunts/items/{item_id}',
     summary="Деактивировать товар"
 )
 async def delete_item(item_id:int) -> Item:
-    deleted_item = await item.delete(item_id)
-    return deleted_item
+    return await item.delete(item_id)
 
 
 @router.patch(
@@ -59,23 +56,7 @@ async def delete_item(item_id:int) -> Item:
     summary="Восстановить ранее деактивированый товар"
 )
 async def restore_item(item_id:int) -> Item:
-    restored_item = await item.restore(item_id)
-    return restored_item
-
-
-@router.get('/restaraunts/{restaraunt_id}/orders/{order_id}/items', summary="Получить список всех товаров в заказе")
-async def get_all_ordered(order_id: int) -> list[OrderedItem]:
-    ordered_items = await ordereditem.get_all_ordered(order_id)
-    return ordered_items
-
-
-@router.get(
-    '/restaraunts/{restaraunt_id}/orders/{order_id}/items/{item_id}',
-    summary="Получить детальную информацию о товаре в заказе"
-)
-async def get_ordered_item(order_id: int, item_id: int) -> OrderedItem:
-    i = await ordereditem.get_ordereditem(order_id, item_id)
-    return i
+    return await item.restore(item_id)
 
 
 @router.post(

--- a/src/restaraunts/endpoints/v1/item.py
+++ b/src/restaraunts/endpoints/v1/item.py
@@ -3,7 +3,7 @@ from src.restaraunts.repo import item, ordereditem
 from src.restaraunts.schemas.item import Item, ItemCreate, ItemResponse
 from src.restaraunts.schemas.ordereditem import OrderedItem, OrderedItemStatus, OrderedItemResponse, OrderedItemStatusUpdate
 
-router = APIRouter(tags=['item'])
+router = APIRouter()
 
 
 @router.get('/restaraunts/items', summary="Получить список всех товаров")

--- a/src/restaraunts/endpoints/v1/item.py
+++ b/src/restaraunts/endpoints/v1/item.py
@@ -1,7 +1,7 @@
-from fastapi import APIRouter, status
-from src.restaraunts.repo import item
+from fastapi import APIRouter, status, HTTPException, Response
+from src.restaraunts.repo import item, ordereditem
 from src.restaraunts.schemas.item import Item, ItemCreate, ItemResponse
-from src.restaraunts.schemas.ordereditem import OrderedItem, OrderedItemStatus
+from src.restaraunts.schemas.ordereditem import OrderedItem, OrderedItemStatus, OrderedItemResponse, OrderedItemStatusUpdate
 
 router = APIRouter(tags=['item'])
 
@@ -13,8 +13,8 @@ async def get_all() -> list[Item]:
 
 
 @router.get(
-        '/restaraunts/{restaraunt_id}/menu/{menu_id}/items',
-        summary="Получить список всех товаров (для меню)"
+    '/restaraunts/{restaraunt_id}/menu/{menu_id}/items',
+    summary="Получить список всех товаров (для меню)"
 )
 async def get_all_for_m(menu_id: int) -> list[Item]:
     items= await item.get_all_for_menu(menu_id)
@@ -22,8 +22,8 @@ async def get_all_for_m(menu_id: int) -> list[Item]:
 
 
 @router.get(
-        '/restaraunts/{restaraunt_id}/menu/{menu_id}/items/{item_id}',
-        summary="Получить детальную информацию о товаре (для меню)"
+    '/restaraunts/{restaraunt_id}/menu/{menu_id}/items/{item_id}',
+    summary="Получить детальную информацию о товаре (для меню)"
 )
 async def get_item(menu_id: int, item_id: int) -> Item:
     i = await item.get_item_for_menu(menu_id, item_id)
@@ -45,47 +45,84 @@ async def create_item(item_data: ItemCreate) -> ItemResponse:
     )
 
 
-@router.get('/restaraunts/{restaraunt_id}/orders/{order_id}/items')
-async def get_ordereditems():
-    ...
+@router.patch(
+    '/restaraunts/items/{item_id}/deactivate',
+    summary="Деактивировать товар"
+)
+async def delete_item(item_id:int) -> Item:
+    deleted_item = await item.delete(item_id)
+    return deleted_item
 
 
-@router.get('/restaraunts/{restaraunt_id}/orders/{order_id}/items/{item_id}')
-async def get_ordereditem(
-        item_id: str
-) -> OrderedItem:
-    ...
-    # return OrderedItem(
-    #     id= item_id,
-    #     created_at= datetime.now(),
-    #     updated_at= datetime.now(),
-    #     item= test_item,
-    #     status= 'Не готов',
-    #     price= 999
-    # )
+@router.patch(
+    '/restaraunts/items/{item_id}/restore',
+    summary="Восстановить ранее деактивированый товар"
+)
+async def restore_item(item_id:int) -> Item:
+    restored_item = await item.restore(item_id)
+    return restored_item
 
 
-
-@router.post('/restaraunts/{restaraunt_id}/orders/{order_id}/items/{item_id}')
-async def add_item_to_order(
-    order_id: str,
-    item_id: str
-):
-    pass
+@router.get('/restaraunts/{restaraunt_id}/orders/{order_id}/items', summary="Получить список всех товаров в заказе")
+async def get_all_ordered(order_id: int) -> list[OrderedItem]:
+    ordered_items = await ordereditem.get_all_ordered(order_id)
+    return ordered_items
 
 
+@router.get(
+    '/restaraunts/{restaraunt_id}/orders/{order_id}/items/{item_id}',
+    summary="Получить детальную информацию о товаре в заказе"
+)
+async def get_ordered_item(order_id: int, item_id: int) -> OrderedItem:
+    i = await ordereditem.get_ordereditem(order_id, item_id)
+    return i
 
-@router.patch("/restaraunts/{restaraunt_id}/orders/{order_id}/items/{item_id}", response_model=dict)
-def update_ordereditem_status(
-    item_id: int, 
-    ordereditem_update: OrderedItemStatus
-):
-    pass
+
+@router.post(
+    '/restaraunts/{restaraunt_id}/orders/{order_id}/items/{item_id}',
+    summary="Добавить товар в заказ"  
+)
+async def add_item_to_order(order_id: int, item_id: int) -> OrderedItemResponse:
+    item = await ordereditem.add_ordered_item(item_id, order_id)
+    if item is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, 
+            detail="Order or Item not found"
+        )
+    return OrderedItemResponse(
+        item_id=item.id,
+        status=OrderedItemStatus.NOT_READY,
+        price=item.price,
+        order_id=item.order_id
+    )
 
 
-@router.delete('/restaraunts/{restaraunt_id}/orders/{order_id}/items/{item_id}')
-async def delete_ordereditem_from_order(
-    item_id: str,
-    order_id: str
-):
-    pass
+@router.patch(
+    "/restaraunts/{restaraunt_id}/orders/{order_id}/items/{item_id}",
+    summary="Изменить статус заказанного товара"
+)
+async def update_ordereditem_status(item_id: int, status_data: OrderedItemStatusUpdate) -> OrderedItem:
+    updated_item = await ordereditem.update_status(item_id, status_data.new_status)
+    if not updated_item:
+        raise HTTPException(status_code=404, detail="Item not found")    
+    return updated_item
+
+
+@router.delete(
+    '/restaraunts/{restaraunt_id}/orders/{order_id}/items/{item_id}',
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Удалить товар из заказа"
+)
+async def delete_item(order_id: int, item_id: int):
+    ordered_item = await ordereditem.get_ordereditem(order_id, item_id)
+    if not ordered_item:
+        raise HTTPException(status_code=404, detail="Товар в заказе не найден")
+    if ordered_item.status != "Не готов":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Нельзя удалить товар, который уже готов"
+        )
+    success = await ordereditem.remove_from_order(order_id, item_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Товар не найден или уже готов")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/restaraunts/endpoints/v1/menu.py
+++ b/src/restaraunts/endpoints/v1/menu.py
@@ -3,7 +3,7 @@ from src.restaraunts.schemas.menu import Menu, MenuCreate, MenuResponse
 from src.restaraunts.schemas.menuitem import LinkItemResponse
 from src.restaraunts.repo import menu, item
 
-router = APIRouter(tags=['menu'])
+router = APIRouter()
 
 @router.get('/restaraunts/menus', summary="Получить список всех меню")
 async def get_all() -> list[Menu]:

--- a/src/restaraunts/endpoints/v1/menu.py
+++ b/src/restaraunts/endpoints/v1/menu.py
@@ -43,7 +43,7 @@ async def create_menu(menu_data: MenuCreate) -> MenuResponse:
     responses={204: {"model": None}}
 )
 async def add_item_to_menu(menu_id: int, item_id: int) -> LinkItemResponse:
-    result = await menu.link_menu_and_iten(menu_id, item_id)
+    result = await menu.link_menu_and_item(menu_id, item_id)
     if result == "not_found":
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/src/restaraunts/endpoints/v1/menu.py
+++ b/src/restaraunts/endpoints/v1/menu.py
@@ -2,25 +2,23 @@ from fastapi import APIRouter, status, HTTPException, Response
 from src.restaraunts.schemas.menu import Menu, MenuCreate, MenuResponse
 from src.restaraunts.schemas.menuitem import LinkItemResponse
 from src.restaraunts.repo import menu, item
+from typing import List
 
 router = APIRouter()
 
 @router.get('/restaraunts/menus', summary="Получить список всех меню")
-async def get_all() -> list[Menu]:
-    menus = await menu.get_all()
-    return menus
+async def get_all() -> List[Menu]:
+    return await menu.get_all()
 
 
 @router.get('/restaraunts/{restaraunt_id}/menu', summary="Получить список всех меню (для ресторана)")
-async def get_all_for_r(restaraunt_id: int) -> list[Menu]:
-    menus = await menu.get_all_for_restaraunt(restaraunt_id)
-    return menus
+async def get_all_for_r(restaraunt_id: int) -> List[Menu]:
+    return await menu.get_all_for_restaraunt(restaraunt_id)
 
 
 @router.get('/restaraunts/{restaraunt_id}/menu/{menu_id}', summary="Получить детальную информацию о меню (для ресторана)")
 async def get_menu(restaraunt_id: int, menu_id: int) -> Menu:
-    m = await menu.get_menu_for_restaraunt(restaraunt_id, menu_id)
-    return m
+    return await menu.get_menu_for_restaraunt(restaraunt_id, menu_id)
 
 
 @router.post(

--- a/src/restaraunts/endpoints/v1/order.py
+++ b/src/restaraunts/endpoints/v1/order.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, status, HTTPException
 from src.restaraunts.schemas.order import Order, OrderCreate, OrderResponse, OrderStatusUpdate
-from src.restaraunts.repo import order
+from src.restaraunts.schemas.ordereditem import OrderedItem
+from src.restaraunts.repo import order, ordereditem
+from typing import List
 
 router = APIRouter()
 
@@ -8,9 +10,8 @@ router = APIRouter()
         '/restaraunts/{restaraunt_id}/orders',
         summary="Получить список всех заказов (для ресторана)"
 )
-async def get_all_for_r(restaraunt_id: int) -> list[Order]:
-    orders = await order.get_all_for_restaraunt(restaraunt_id)
-    return orders
+async def get_all_for_r(restaraunt_id: int) -> List[Order]:
+    return await order.get_all_for_restaraunt(restaraunt_id)
 
 
 @router.get(
@@ -18,8 +19,7 @@ async def get_all_for_r(restaraunt_id: int) -> list[Order]:
         summary="Получить детальную информацию о заказе (для ресторана)"
 )
 async def get_order(restaraunt_id: int, order_id: int) -> Order:
-    o = await order.get_order_for_restaraunt(restaraunt_id, order_id)
-    return o
+    return await order.get_order_for_restaraunt(restaraunt_id, order_id)
 
 
 @router.post(
@@ -46,3 +46,17 @@ async def update_order_status(order_id: int, status_data: OrderStatusUpdate) -> 
     if not updated_order:
         raise HTTPException(status_code=404, detail="Order not found")    
     return updated_order
+
+
+@router.get('/restaraunts/{restaraunt_id}/orders/{order_id}/items', summary="Получить список всех товаров в заказе")
+async def get_all_ordered(order_id: int) -> List[OrderedItem]:
+    return await ordereditem.get_all_ordered(order_id)
+
+
+@router.get(
+    '/restaraunts/{restaraunt_id}/orders/{order_id}/items/{item_id}',
+    summary="Получить детальную информацию о товаре в заказе"
+)
+async def get_ordered_item(order_id: int, item_id: int) -> OrderedItem:
+    return await ordereditem.get_ordereditem(order_id, item_id)
+

--- a/src/restaraunts/endpoints/v1/order.py
+++ b/src/restaraunts/endpoints/v1/order.py
@@ -37,7 +37,6 @@ async def create_order(restaraunt_id: int, order_data: OrderCreate) -> OrderResp
     )
 
 
-
 @router.patch(
         '/restaraunts/{restaraunt_id}/orders/{order_id}',
         summary="Изменить статус заказа"

--- a/src/restaraunts/endpoints/v1/order.py
+++ b/src/restaraunts/endpoints/v1/order.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, status, HTTPException
 from src.restaraunts.schemas.order import Order, OrderCreate, OrderResponse, OrderStatusUpdate
 from src.restaraunts.repo import order
 
-router = APIRouter(tags=['order'])
+router = APIRouter()
 
 @router.get(
         '/restaraunts/{restaraunt_id}/orders',

--- a/src/restaraunts/endpoints/v1/restaraunt.py
+++ b/src/restaraunts/endpoints/v1/restaraunt.py
@@ -3,13 +3,13 @@ from src.restaraunts.schemas.restaraunt import Restaraunt
 from src.restaraunts.schemas.restarauntmenu import LinkMenuResponse
 from src.restaraunts.repo import restaraunt
 from src.restaraunts.repo import menu
+from typing import List
 
 router = APIRouter()
 
 @router.get('/restaraunts', summary="Получить список всех ресторанов")
-async def get_restaraunts() -> list[Restaraunt]:
-    restaraunts = await restaraunt.get_all()
-    return restaraunts
+async def get_restaraunts() -> List[Restaraunt]:
+    return await restaraunt.get_all()
 
 
 @router.get('/restaraunts/{restaraunt_id}', summary="Получить детальную информацию о ресторане")

--- a/src/restaraunts/endpoints/v1/restaraunt.py
+++ b/src/restaraunts/endpoints/v1/restaraunt.py
@@ -4,7 +4,7 @@ from src.restaraunts.schemas.restarauntmenu import LinkMenuResponse
 from src.restaraunts.repo import restaraunt
 from src.restaraunts.repo import menu
 
-router = APIRouter(tags=['restaraunts'])
+router = APIRouter()
 
 @router.get('/restaraunts', summary="Получить список всех ресторанов")
 async def get_restaraunts() -> list[Restaraunt]:

--- a/src/restaraunts/endpoints/v2/item.py
+++ b/src/restaraunts/endpoints/v2/item.py
@@ -1,0 +1,3 @@
+from fastapi import APIRouter
+
+router = APIRouter(tags=['item'])

--- a/src/restaraunts/endpoints/v2/menu.py
+++ b/src/restaraunts/endpoints/v2/menu.py
@@ -1,13 +1,17 @@
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, status, HTTPException, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 from src.restaraunts.database import get_db
 from src.restaraunts.schemas.menu import Menu, MenuCreate, MenuResponse
+from src.restaraunts.schemas.menuitem import LinkItemResponse
 from src.restaraunts.services import menu
+from src.restaraunts.services import item
+from src.restaraunts.auth.deps import AuthTokenDep
 
 router = APIRouter()
 
 @router.get('/restaraunts/menus', summary="Получить список всех меню")
-async def get_all(db: AsyncSession = Depends(get_db)) -> list[Menu]:
+async def get_all(token:AuthTokenDep, db: AsyncSession = Depends(get_db)) -> list[Menu]:
+    print(f'{token=}', flush=True)
     return await menu.get_all(db)
 
 
@@ -23,4 +27,26 @@ async def get_menu(menu_id: int, db: AsyncSession = Depends(get_db)) -> Menu:
 )
 async def create_menu(menu_data: MenuCreate, db: AsyncSession = Depends(get_db)) -> MenuResponse:
     return await menu.add_menu(menu_data, db)
-   
+
+
+@router.post(
+    "/restaraunts/{restaraunt_id}/menu/{menu_id}/items/{item_id}",
+    status_code=status.HTTP_201_CREATED,
+    summary="Привязать товар к меню",
+    responses={204: {"model": None}}
+)
+async def add_item_to_menu(menu_id: int, item_id: int, db: AsyncSession = Depends(get_db)) -> LinkItemResponse:
+    result = await menu.link_menu_and_item(menu_id, item_id, db)
+    if result == "not_found":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Menu or Item not found"
+        )
+    if result == "already_exists":
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    all_items = await item.get_all_for_menu(menu_id)
+    return LinkItemResponse(
+        status="created",
+        menu_id=menu_id,
+        items=all_items
+    )

--- a/src/restaraunts/endpoints/v2/menu.py
+++ b/src/restaraunts/endpoints/v2/menu.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from src.restaraunts.database import get_db
+from src.restaraunts.schemas.menu import Menu
+from src.restaraunts.services import menu
+
+router = APIRouter(tags=['menu'])
+
+@router.get('/restaraunts/menus', summary="Получить список всех меню")
+async def get_all(db: AsyncSession = Depends(get_db)) -> list[Menu]:
+    menus = await menu.get_all(db)
+    return menus

--- a/src/restaraunts/endpoints/v2/menu.py
+++ b/src/restaraunts/endpoints/v2/menu.py
@@ -1,12 +1,26 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from src.restaraunts.database import get_db
-from src.restaraunts.schemas.menu import Menu
+from src.restaraunts.schemas.menu import Menu, MenuCreate, MenuResponse
 from src.restaraunts.services import menu
 
-router = APIRouter(tags=['menu'])
+router = APIRouter()
 
 @router.get('/restaraunts/menus', summary="Получить список всех меню")
 async def get_all(db: AsyncSession = Depends(get_db)) -> list[Menu]:
-    menus = await menu.get_all(db)
-    return menus
+    return await menu.get_all(db)
+
+
+@router.get('/restaraunts/menus/{menu_id}', summary="Получить детальную информацию о меню")
+async def get_menu(menu_id: int, db: AsyncSession = Depends(get_db)) -> Menu:
+    return await menu.get_one(menu_id, db)
+
+
+@router.post(
+    "/restaraunts/menus", 
+    status_code=status.HTTP_201_CREATED,
+    summary="Создать новое меню"
+)
+async def create_menu(menu_data: MenuCreate, db: AsyncSession = Depends(get_db)) -> MenuResponse:
+    return await menu.add_menu(menu_data, db)
+   

--- a/src/restaraunts/endpoints/v2/order.py
+++ b/src/restaraunts/endpoints/v2/order.py
@@ -1,0 +1,3 @@
+from fastapi import APIRouter
+
+router = APIRouter(tags=['order'])

--- a/src/restaraunts/endpoints/v2/restaraunt.py
+++ b/src/restaraunts/endpoints/v2/restaraunt.py
@@ -1,0 +1,3 @@
+from fastapi import APIRouter
+
+router = APIRouter(tags=['restaraunts'])

--- a/src/restaraunts/entities/__init__.py
+++ b/src/restaraunts/entities/__init__.py
@@ -1,0 +1,6 @@
+from .restaraunt import Restaraunt
+from .order import Order
+from .menu import Menu
+from .ordereditem import OrderedItem
+from .item import Item
+from .associations import menu_item_association, restaraunt_menu_association

--- a/src/restaraunts/entities/associations.py
+++ b/src/restaraunts/entities/associations.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Table, Column, ForeignKey
+from .base import Base
+
+restaraunt_menu_association = Table(
+    "Restarauntmenus",
+    Base.metadata,
+    Column("restaraunt_id", ForeignKey("Restaraunts.id"), primary_key=True),
+    Column("menu_id", ForeignKey("Menus.id"), primary_key=True),
+)
+
+
+menu_item_association = Table(
+    "Menuitems",
+    Base.metadata,
+    Column("menu_id", ForeignKey("Menus.id"), primary_key=True),
+    Column("item_id", ForeignKey("Items.id"), primary_key=True),
+)

--- a/src/restaraunts/entities/base.py
+++ b/src/restaraunts/entities/base.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+from sqlalchemy import func, DateTime
+from sqlalchemy.orm import DeclarativeBase, mapped_column, Mapped
+
+class Base(DeclarativeBase):
+    pass
+
+
+class TimeStamped(Base):
+    __abstract__ = True
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, 
+        server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, 
+        server_default=func.now(),
+        onupdate=func.now()
+    )
+
+
+class TimeStampedWithId(TimeStamped):
+    __abstract__ = True
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True, index=True)

--- a/src/restaraunts/entities/item.py
+++ b/src/restaraunts/entities/item.py
@@ -1,0 +1,18 @@
+from typing import List, TYPE_CHECKING
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from .base import TimeStampedWithId
+from .associations import menu_item_association
+if TYPE_CHECKING:
+    from .ordereditem import OrderedItem
+    from .menu import Menu
+
+
+class Item(TimeStampedWithId):
+    __tablename__ = 'Items'
+
+    price: Mapped[float]
+    name: Mapped[str]
+    is_active: Mapped[bool] = mapped_column(default=1)
+
+    ordereditems: Mapped[List["OrderedItem"]] = relationship(back_populates="item")
+    menus: Mapped[list["Menu"]] = relationship(secondary=menu_item_association, back_populates="items")

--- a/src/restaraunts/entities/menu.py
+++ b/src/restaraunts/entities/menu.py
@@ -1,0 +1,17 @@
+from typing import TYPE_CHECKING
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from .base import TimeStampedWithId
+from .associations import restaraunt_menu_association
+from .associations import menu_item_association
+if TYPE_CHECKING:
+    from .restaraunt import Restaraunt
+    from .item import Item
+
+class Menu(TimeStampedWithId):
+    __tablename__ = 'Menus'
+
+    name: Mapped[str]
+    version: Mapped[int] = mapped_column(default=1)
+
+    restaraunts: Mapped[list["Restaraunt"]] = relationship(secondary=restaraunt_menu_association, back_populates="menus")
+    items: Mapped[list["Item"]] = relationship(secondary=menu_item_association, back_populates="menus")

--- a/src/restaraunts/entities/order.py
+++ b/src/restaraunts/entities/order.py
@@ -1,0 +1,30 @@
+from typing import List, TYPE_CHECKING
+from sqlalchemy import ForeignKey, Enum
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+if TYPE_CHECKING:
+    from .restaraunt import Restaraunt
+    from .ordereditem import OrderedItem
+from .base import TimeStampedWithId
+import enum
+
+
+class OrderStatus(str, enum.Enum):
+    NEW = 'Новый'
+    COMPLETED = 'Сформирован'
+    READY = 'Готов'
+    PAID = 'Оплачен'
+
+
+class Order(TimeStampedWithId):
+    __tablename__ = 'Orders'
+
+    status: Mapped[OrderStatus] = mapped_column(
+        Enum(OrderStatus),
+        default=OrderStatus.NEW,
+        nullable=False
+    )
+    price: Mapped[float]
+    restaraunt_id: Mapped[int] = mapped_column(ForeignKey("Restaraunts.id"))
+
+    restaraunt: Mapped["Restaraunt"] = relationship(back_populates="orders")
+    ordereditems: Mapped[List["OrderedItem"]] = relationship(back_populates="order")

--- a/src/restaraunts/entities/ordereditem.py
+++ b/src/restaraunts/entities/ordereditem.py
@@ -1,0 +1,30 @@
+from typing import TYPE_CHECKING
+from sqlalchemy import ForeignKey, Enum
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+if TYPE_CHECKING:
+    from .item import Item
+    from .order import Order
+from .base import TimeStampedWithId
+import enum
+
+
+class OrderedItemStatus(str, enum.Enum):
+    NOT_READY = 'Не готов'
+    READY_FOR_DELIVERY = 'Готов к выдаче'
+    DELIVERED = 'Выдан'
+
+
+class OrderedItem(TimeStampedWithId):
+    __tablename__ = 'OrderedItems'
+
+    item_id: Mapped[int] = mapped_column(ForeignKey("Items.id"))
+    status: Mapped[OrderedItemStatus] = mapped_column(
+        Enum(OrderedItemStatus),
+        default=OrderedItemStatus.NOT_READY,
+        nullable=False
+    )
+    price: Mapped[float]
+    order_id: Mapped[int] = mapped_column(ForeignKey("Orders.id"))
+
+    item: Mapped["Item"] = relationship(back_populates="ordereditems")
+    order: Mapped["Order"] = relationship(back_populates="ordereditems")

--- a/src/restaraunts/entities/restaraunt.py
+++ b/src/restaraunts/entities/restaraunt.py
@@ -1,0 +1,16 @@
+from typing import List, TYPE_CHECKING
+from sqlalchemy.orm import Mapped, relationship
+from .base import TimeStampedWithId
+from .associations import restaraunt_menu_association
+if TYPE_CHECKING:
+    from .order import Order
+    from .menu import Menu
+
+
+class Restaraunt(TimeStampedWithId):
+    __tablename__ = 'Restaraunts'
+
+    name: Mapped[str]
+
+    orders: Mapped[List["Order"]] = relationship(back_populates="restaraunt")
+    menus: Mapped[list["Menu"]] = relationship(secondary=restaraunt_menu_association, back_populates="restaraunts")

--- a/src/restaraunts/main.py
+++ b/src/restaraunts/main.py
@@ -1,9 +1,28 @@
+from contextlib import asynccontextmanager
 from fastapi import FastAPI
-from src.restaraunts.endpoints import v1_router
+from src.restaraunts.entities.base import Base
+from src.restaraunts.entities import *
+from src.restaraunts.database import test_conn, engine
+from src.restaraunts.endpoints import v1_router, v2_router
 
-app = FastAPI()
+@asynccontextmanager
+async def on_start(app:FastAPI):
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+
+
+app = FastAPI(
+    title="Restaurant API",
+    description="V1 - SQL, V2 - SQLAlchemy ORM",
+    version="2.0.0",
+    lifespan=on_start
+)
 app.include_router(v1_router, prefix="/api")
+app.include_router(v2_router, prefix="/api")
+
 
 @app.get('/test')
 async def get_test():
+    await test_conn()
     return {"status": "OK"}

--- a/src/restaraunts/repo/item.py
+++ b/src/restaraunts/repo/item.py
@@ -41,12 +41,16 @@ async def add_item(name, price) -> int:
 #asyncio.run(add_item("Кофе", 250))
 
 
-async def delete_item(item_id: int):
+async def delete(item_id: int):
     async with get_cursor() as cursor:
-        await cursor.execute(
-            "UPDATE Items SET is_active = 0 WHERE id = ?",
-            (item_id,)
-        )
+        await cursor.execute('''
+            UPDATE Items 
+            SET is_active = 0 
+            WHERE id = ?
+            RETURNING *
+        ''', (item_id,))
+        row = await cursor.fetchone() 
+        return Item(**dict(row))
 
 
 async def get_all(show_archived=False):
@@ -92,10 +96,14 @@ async def get_item_for_menu(menu_id: int, item_id: int):
         return Item(**dict(row))
 
 
-async def restore_item(item_id: int):
-    """Восстанавливает ранее деактивированный товар."""
+async def restore(item_id: int):
     async with get_cursor() as cursor:
-        await cursor.execute(
-            "UPDATE Items SET is_active = 1 WHERE id = ?",
-            (item_id,)
-        )
+        await cursor.execute('''
+            UPDATE Items 
+            SET is_active = 1 
+            WHERE id = ?
+            RETURNING *
+        ''', (item_id,))
+        row = await cursor.fetchone() 
+        return Item(**dict(row))
+

--- a/src/restaraunts/repo/item.py
+++ b/src/restaraunts/repo/item.py
@@ -1,5 +1,6 @@
 from src.restaraunts.database import get_cursor
 from src.restaraunts.schemas.item import Item
+from typing import List
 #import asyncio
 
 
@@ -41,7 +42,7 @@ async def add_item(name, price) -> int:
 #asyncio.run(add_item("Кофе", 250))
 
 
-async def delete(item_id: int):
+async def delete(item_id: int) -> Item:
     async with get_cursor() as cursor:
         await cursor.execute('''
             UPDATE Items 
@@ -53,7 +54,7 @@ async def delete(item_id: int):
         return Item(**dict(row))
 
 
-async def get_all(show_archived=False):
+async def get_all(show_archived=False) -> List[Item]:
     """
     Получает список всех товаров.
     :param show_archived: Если True, вернет в том числе и 'удаленные' товары.
@@ -67,7 +68,7 @@ async def get_all(show_archived=False):
         return [Item(**dict(row)) for row in rows]
 
 
-async def get_all_for_menu(menu_id: int):
+async def get_all_for_menu(menu_id: int) -> List[Item]:
     async with get_cursor() as cursor:
         query = '''
             SELECT i.* 
@@ -80,7 +81,7 @@ async def get_all_for_menu(menu_id: int):
         return [Item(**dict(row)) for row in rows]
     
 
-async def get_item_for_menu(menu_id: int, item_id: int):
+async def get_item_for_menu(menu_id: int, item_id: int) -> Item | None:
     async with get_cursor() as cursor:
         query = '''
             SELECT i.* 
@@ -96,7 +97,7 @@ async def get_item_for_menu(menu_id: int, item_id: int):
         return Item(**dict(row))
 
 
-async def restore(item_id: int):
+async def restore(item_id: int) -> Item:
     async with get_cursor() as cursor:
         await cursor.execute('''
             UPDATE Items 
@@ -106,4 +107,3 @@ async def restore(item_id: int):
         ''', (item_id,))
         row = await cursor.fetchone() 
         return Item(**dict(row))
-

--- a/src/restaraunts/repo/menu.py
+++ b/src/restaraunts/repo/menu.py
@@ -75,7 +75,7 @@ async def get_menu_for_restaraunt(restaraunt_id: int, menu_id: int):
         return Menu(**dict(row))
     
 
-async def link_menu_and_iten(menu_id: int, item_id: int):
+async def link_menu_and_item(menu_id: int, item_id: int):
     async with get_cursor() as cursor:
         try:
             await cursor.execute('''

--- a/src/restaraunts/repo/menu.py
+++ b/src/restaraunts/repo/menu.py
@@ -1,5 +1,6 @@
 from src.restaraunts.database import get_cursor
 from src.restaraunts.schemas.menu import Menu
+from typing import List
 import sqlite3
 #import asyncio
 
@@ -39,14 +40,14 @@ async def add_menu(name: str) -> int:
         return cursor.lastrowid
 
 
-async def get_all():
+async def get_all() -> List[Menu]:
     async with get_cursor() as cursor:
         await cursor.execute("SELECT * FROM Menus")
         rows = await cursor.fetchall() 
         return [Menu(**dict(row)) for row in rows]
 
 
-async def get_all_for_restaraunt(restaraunt_id: int):
+async def get_all_for_restaraunt(restaraunt_id: int) -> List[Menu]:
     async with get_cursor() as cursor:
         query = '''
             SELECT m.* 
@@ -59,7 +60,7 @@ async def get_all_for_restaraunt(restaraunt_id: int):
         return [Menu(**dict(row)) for row in rows]
     
 
-async def get_menu_for_restaraunt(restaraunt_id: int, menu_id: int):
+async def get_menu_for_restaraunt(restaraunt_id: int, menu_id: int) -> Menu | None:
     async with get_cursor() as cursor:
         query = '''
             SELECT m.* 
@@ -75,7 +76,7 @@ async def get_menu_for_restaraunt(restaraunt_id: int, menu_id: int):
         return Menu(**dict(row))
     
 
-async def link_menu_and_item(menu_id: int, item_id: int):
+async def link_menu_and_item(menu_id: int, item_id: int) -> str:
     async with get_cursor() as cursor:
         try:
             await cursor.execute('''

--- a/src/restaraunts/repo/order.py
+++ b/src/restaraunts/repo/order.py
@@ -1,5 +1,6 @@
 from src.restaraunts.database import get_cursor
 from src.restaraunts.schemas.order import Order
+from typing import List
 #import asyncio
 
 
@@ -31,7 +32,7 @@ async def init_db():
 #asyncio.run(init_db())
 
 
-async def add_order(price, restaraunt_id):
+async def add_order(price, restaraunt_id) -> int:
     async with get_cursor() as cursor:
         await cursor.execute('''
             INSERT INTO Orders (price, restaraunt_id)
@@ -40,7 +41,7 @@ async def add_order(price, restaraunt_id):
         return cursor.lastrowid
 
 
-async def update_status(order_id, new_status):
+async def update_status(order_id, new_status) -> Order:
     async with get_cursor() as cursor:
         await cursor.execute('''
             UPDATE Orders
@@ -52,7 +53,7 @@ async def update_status(order_id, new_status):
         return Order(**dict(row))
 
 
-async def get_all_for_restaraunt(restaraunt_id: int):
+async def get_all_for_restaraunt(restaraunt_id: int) -> List[Order]:
     async with get_cursor() as cursor:
         await cursor.execute('''
             SELECT * 
@@ -63,7 +64,7 @@ async def get_all_for_restaraunt(restaraunt_id: int):
         return [Order(**dict(row)) for row in rows]
     
 
-async def get_order_for_restaraunt(restaraunt_id: int, order_id: int):
+async def get_order_for_restaraunt(restaraunt_id: int, order_id: int) -> Order | None:
     async with get_cursor() as cursor:
         await cursor.execute('''
             SELECT * 

--- a/src/restaraunts/repo/ordereditem.py
+++ b/src/restaraunts/repo/ordereditem.py
@@ -1,5 +1,6 @@
 from src.restaraunts.database import get_cursor
 from src.restaraunts.schemas.ordereditem import OrderedItem
+from typing import List
 #import asyncio
 
 
@@ -33,7 +34,7 @@ async def init_db():
 #asyncio.run(init_db())
 
 
-async def add_ordered_item(item_id: int, order_id: int):
+async def add_ordered_item(item_id: int, order_id: int) -> OrderedItem | None:
     async with get_cursor() as cursor:
         await cursor.execute('''
             INSERT INTO OrderedItems (item_id, order_id, price)
@@ -48,7 +49,7 @@ async def add_ordered_item(item_id: int, order_id: int):
         return OrderedItem(**dict(row))
     
 
-async def get_all_ordered(order_id: int):
+async def get_all_ordered(order_id: int) -> List[OrderedItem]:
     async with get_cursor() as cursor:
         await cursor.execute('''
             SELECT * 
@@ -59,7 +60,7 @@ async def get_all_ordered(order_id: int):
         return [OrderedItem(**dict(row)) for row in rows]
 
 
-async def get_ordereditem(order_id: int, ordereditem_id: int):
+async def get_ordereditem(order_id: int, ordereditem_id: int) -> OrderedItem | None:
     async with get_cursor() as cursor:
         await cursor.execute('''
             SELECT * 
@@ -73,7 +74,7 @@ async def get_ordereditem(order_id: int, ordereditem_id: int):
         return OrderedItem(**dict(row))
 
     
-async def update_status(ordereditem_id, new_status):
+async def update_status(ordereditem_id, new_status) -> OrderedItem:
     async with get_cursor() as cursor:
         await cursor.execute('''
             UPDATE OrderedItems

--- a/src/restaraunts/repo/ordereditem.py
+++ b/src/restaraunts/repo/ordereditem.py
@@ -1,4 +1,5 @@
 from src.restaraunts.database import get_cursor
+from src.restaraunts.schemas.ordereditem import OrderedItem
 #import asyncio
 
 
@@ -32,19 +33,65 @@ async def init_db():
 #asyncio.run(init_db())
 
 
-async def add_ordered_item(item_id, status, price, order_id):
+async def add_ordered_item(item_id: int, order_id: int):
     async with get_cursor() as cursor:
         await cursor.execute('''
-            INSERT INTO OrderedItems (item_id, "status", price, order_id)
-            VALUES (?, ?, ?, ?)
-        ''', (item_id, status, price, order_id))
-        return cursor.lastrowid
+            INSERT INTO OrderedItems (item_id, order_id, price)
+            SELECT id, ?, price 
+            FROM Items 
+            WHERE id = ?
+            RETURNING *
+        ''', (order_id, item_id))
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        return OrderedItem(**dict(row))
     
 
-async def update_item_status(ordereditem_id, new_status):
+async def get_all_ordered(order_id: int):
+    async with get_cursor() as cursor:
+        await cursor.execute('''
+            SELECT * 
+            FROM OrderedItems
+            WHERE order_id = ?
+        ''', (order_id,))
+        rows = await cursor.fetchall()
+        return [OrderedItem(**dict(row)) for row in rows]
+
+
+async def get_ordereditem(order_id: int, ordereditem_id: int):
+    async with get_cursor() as cursor:
+        await cursor.execute('''
+            SELECT * 
+            FROM OrderedItems
+            WHERE order_id = ?
+            AND id = ?
+        ''', (order_id, ordereditem_id))
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        return OrderedItem(**dict(row))
+
+    
+async def update_status(ordereditem_id, new_status):
     async with get_cursor() as cursor:
         await cursor.execute('''
             UPDATE OrderedItems
             SET "status" = ?
             WHERE id = ?
+            RETURNING *
         ''', (new_status, ordereditem_id))
+        row = await cursor.fetchone() 
+        return OrderedItem(**dict(row))
+
+
+async def remove_from_order(order_id: int, item_id: int) -> bool:
+    async with get_cursor() as cursor:
+        await cursor.execute('''
+            DELETE FROM OrderedItems
+            WHERE order_id = ? 
+              AND id = ? 
+              AND status = 'Не готов'
+        ''', (order_id, item_id))
+        
+        return cursor.rowcount > 0

--- a/src/restaraunts/repo/restaraunt.py
+++ b/src/restaraunts/repo/restaraunt.py
@@ -1,5 +1,6 @@
 from src.restaraunts.database import get_cursor
 from src.restaraunts.schemas.restaraunt import Restaraunt
+from typing import List
 import sqlite3
 #import asyncio
 
@@ -28,15 +29,14 @@ async def init_db():
 #asyncio.run(init_db())
 
 
-async def get_all():
+async def get_all() -> List[Restaraunt]:
     async with get_cursor() as cursor:
         await cursor.execute("SELECT * FROM Restaraunts")
-        rows = await cursor.fetchall() 
-        # Превращаем каждую строку в объект Restaraunt
+        rows = await cursor.fetchall()
         return [Restaraunt(**dict(row)) for row in rows]
 
 
-async def get_restaraunt(restaraunt_id: int):
+async def get_restaraunt(restaraunt_id: int) -> Restaraunt | None:
     async with get_cursor() as cursor:
         await cursor.execute(
             "SELECT * FROM Restaraunts WHERE id = ?",
@@ -59,7 +59,7 @@ async def add_restaraunt(name):
 #asyncio.run(add_restaraunt('Пхали'))
 
 
-async def link_restaraunt_and_menu(restaraunt_id: int, menu_id: int):
+async def link_restaraunt_and_menu(restaraunt_id: int, menu_id: int) -> str:
     async with get_cursor() as cursor:
         try:
             await cursor.execute('''

--- a/src/restaraunts/schemas/order.py
+++ b/src/restaraunts/schemas/order.py
@@ -10,7 +10,7 @@ class OrderResponse(BaseModel):
     id: int
     price: float
     restaraunt_id: int
-    status: str = "Новый"
+    status: OrderStatus
 
 
 class Order(Base, OrderCreate):

--- a/src/restaraunts/schemas/ordereditem.py
+++ b/src/restaraunts/schemas/ordereditem.py
@@ -1,15 +1,21 @@
 from src.restaraunts.schemas.base import Base
+from pydantic import BaseModel
 import enum
 
-class OrderedItem(Base):
-    item_id: str
+    
+class OrderedItemResponse(BaseModel):
+    item_id: int
     status: OrderedItemStatus
     price: float
-    order_id: str
+    order_id: int
 
+class OrderedItem(Base, OrderedItemResponse):
+    ...
 
-class OrderedItemStatus(enum.StrEnum):
+class OrderedItemStatus(str, enum.Enum):
     NOT_READY = 'Не готов'
     READY_FOR_DELIVERY = 'Готов к выдаче'
     DELIVERED = 'Выдан'
-    
+
+class OrderedItemStatusUpdate(BaseModel):
+    new_status: OrderedItemStatus 

--- a/src/restaraunts/services/item.py
+++ b/src/restaraunts/services/item.py
@@ -3,9 +3,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.restaraunts.entities.item import Item
 from src.restaraunts.entities.menu import Menu
 from src.restaraunts.schemas.item import Item as ItemSchema
+from typing import List
 
 
-async def get_all_for_menu(menu_id: int, session: AsyncSession) -> list[ItemSchema]:
+async def get_all_for_menu(menu_id: int, session: AsyncSession) -> List[ItemSchema]:
     stmt = (
         select(Item)
         .where(Item.menus.any(Menu.id == menu_id)) 

--- a/src/restaraunts/services/item.py
+++ b/src/restaraunts/services/item.py
@@ -1,0 +1,31 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from src.restaraunts.entities.item import Item
+from src.restaraunts.entities.menu import Menu
+from src.restaraunts.schemas.item import Item as ItemSchema
+
+
+async def get_all_for_menu(menu_id: int, session: AsyncSession) -> list[ItemSchema]:
+    stmt = (
+        select(Item)
+        .where(Item.menus.any(Menu.id == menu_id)) 
+    )
+    result = await session.execute(stmt)
+    return [
+        ItemSchema.model_validate(data, from_attributes=True)
+        for data in list(result.scalars().all())
+    ]
+    
+
+async def get_item_for_menu(menu_id: int, item_id: int, session: AsyncSession) -> ItemSchema | None:
+    stmt = (
+        select(Item)
+        .where(Item.id == item_id)
+        .where(Item.menus.any(Menu.id == menu_id))
+    )
+    result = await session.execute(stmt)
+    item_model = result.scalar_one_or_none()
+    if item_model is None:
+        return None
+    return ItemSchema.model_validate(item_model, from_attributes=True)
+    

--- a/src/restaraunts/services/menu.py
+++ b/src/restaraunts/services/menu.py
@@ -1,0 +1,9 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from src.restaraunts.entities.menu import Menu
+
+async def get_all(session: AsyncSession):
+    query = select(Menu) 
+    result = await session.execute(query)
+    
+    return result.scalars().all()

--- a/src/restaraunts/services/menu.py
+++ b/src/restaraunts/services/menu.py
@@ -4,8 +4,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.restaraunts.entities.menu import Menu
 from src.restaraunts.entities.associations import menu_item_association
 from src.restaraunts.schemas.menu import Menu as MenuSchema, MenuCreate, MenuResponse
+from typing import List
 
-async def get_all(session: AsyncSession) -> list[MenuSchema]:
+async def get_all(session: AsyncSession) -> List[MenuSchema]:
     stmt = select(Menu) 
     result = await session.execute(stmt)
     return [
@@ -27,7 +28,7 @@ async def add_menu(menu_create: MenuCreate, session:AsyncSession) -> MenuRespons
     return MenuResponse.model_validate(menu, from_attributes=True)
 
 
-async def link_menu_and_item(menu_id: int, item_id: int, session:AsyncSession):
+async def link_menu_and_item(menu_id: int, item_id: int, session:AsyncSession) -> str:
     data = {"menu_id": menu_id, "item_id": item_id}
     stmt = insert(menu_item_association).values(**data)
     try:

--- a/src/restaraunts/services/menu.py
+++ b/src/restaraunts/services/menu.py
@@ -1,6 +1,8 @@
-from sqlalchemy import select
+from sqlalchemy import select, insert
+import sqlite3
 from sqlalchemy.ext.asyncio import AsyncSession
 from src.restaraunts.entities.menu import Menu
+from src.restaraunts.entities.associations import menu_item_association
 from src.restaraunts.schemas.menu import Menu as MenuSchema, MenuCreate, MenuResponse
 
 async def get_all(session: AsyncSession) -> list[MenuSchema]:
@@ -23,3 +25,17 @@ async def add_menu(menu_create: MenuCreate, session:AsyncSession) -> MenuRespons
     session.add(menu)
     await session.flush()
     return MenuResponse.model_validate(menu, from_attributes=True)
+
+
+async def link_menu_and_item(menu_id: int, item_id: int, session:AsyncSession):
+    data = {"menu_id": menu_id, "item_id": item_id}
+    stmt = insert(menu_item_association).values(**data)
+    try:
+        await session.execute(stmt)
+    except sqlite3.IntegrityError as e:
+            if "FOREIGN KEY constraint failed" in str(e):
+                return "not_found"
+            if "UNIQUE constraint failed" in str(e):
+                return "already_exists"
+            raise e
+    return "success"

--- a/src/restaraunts/services/menu.py
+++ b/src/restaraunts/services/menu.py
@@ -1,9 +1,25 @@
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from src.restaraunts.entities.menu import Menu
+from src.restaraunts.schemas.menu import Menu as MenuSchema, MenuCreate, MenuResponse
 
-async def get_all(session: AsyncSession):
-    query = select(Menu) 
-    result = await session.execute(query)
+async def get_all(session: AsyncSession) -> list[MenuSchema]:
+    stmt = select(Menu) 
+    result = await session.execute(stmt)
+    return [
+        MenuSchema.model_validate(data, from_attributes=True)
+        for data in list(result.scalars().all())
+    ]
     
-    return result.scalars().all()
+
+async def get_one(id: int, session: AsyncSession) -> MenuSchema:
+    stmt = select(Menu).where(Menu.id == id)
+    result = await session.execute(stmt)
+    return MenuSchema.model_validate(result.scalar(), from_attributes=True)
+
+
+async def add_menu(menu_create: MenuCreate, session:AsyncSession) -> MenuResponse:
+    menu = Menu(**menu_create.model_dump())
+    session.add(menu)
+    await session.flush()
+    return MenuResponse.model_validate(menu, from_attributes=True)


### PR DESCRIPTION
1. Дописаны недостающие эндпоинты в версии №1, работающие на прямых SQL-запросах.

2. Внедрение SQLAlchemy (Core & ORM):
Добавлен пакет sqlalchemy в зависимости через poetry.
Создана асинхронная фабрика сессий (async_sessionmaker) с использованием AsyncSession.
Настроена автоматическая поддержка Foreign Keys для SQLite через механизм event.listens_for (команда PRAGMA foreign_keys = ON).
Реализована интеграция сессии БД в FastAPI через Dependency Injection (зависимость get_db). Работоспособность проверена на тестовом эндпоинте.
Создан асинхронный контекстный менеджер для lifespan приложения, который автоматически инициализирует структуру таблиц (create_all) при запуске.
Для изоляции новой логики введена структура роутеров V2, задействован отдельный файл базы данных restaraunts_v2.db.
Описаны ORM-модели для всех сущностей приложения (через Mapped / mapped_column).
Реализованы связи «многие-ко-многим» через таблицы ассоциаций (Association Tables).

Тестирование:
Проверена работа старых эндпоинтов (V1).
Протестировано создание таблиц и выполнение базового запроса через новую сессию ORM.

*промежуточный этап, далее планируется перенос логики API в роутеры V2 и уточнение правил удаления для связей в ORM-моделях

Related to #11 